### PR TITLE
Allow saving Parse Objects with Master Key

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -840,7 +840,7 @@ class ParseObject implements Encodable
    */
   public static function saveAll($list, $useMasterKey = false)
   {
-    static::deepSave($list);
+    static::deepSave($list, $useMasterKey);
   }
 
   /**


### PR DESCRIPTION
Resolves #28.

Arguments are defaulted for backwards compatibility.
