### PR TITLE
Fix bug saving using MasterKey

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -916,7 +916,7 @@ class ParseObject implements Encodable
       if (count($requests) === 1) {
         $req = $requests[0];
         $result = ParseClient::_request($req['method'],
-          $req['path'], $sessionToken, json_encode($req['body']));
+          $req['path'], $sessionToken, json_encode($req['body']), $useMasterKey);
         $batch[0]->mergeAfterSave($result);
       } else {
         $result = ParseClient::_request('POST', '/1/batch', $sessionToken,


### PR DESCRIPTION
If you have a single object that you are trying to save with the MasterKey it does not use the MasterKey to lookup that object.
