### PR TITLE
Fix datetime format used in Local Push Scheduling. Scheduling does not w...

### DIFF
--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -357,4 +357,20 @@ final class ParseClient
     return $date;
   }
 
+  /**
+   * Get a date value in the format to use in Local Push Scheduling on Parse.
+   *
+   * All the SDKs do some slightly different date handling.
+   * Format from Parse doc: an ISO 8601 date without a time zone, i.e. 2014-10-16T12:00:00 .
+   *
+   * @param \DateTime $value DateTime value to format.
+   *
+   * @return string
+   */
+  public static function getLocalPushDateFormat($value)
+  {
+    $dateFormatString = 'Y-m-d\TH:i:s';
+    $date = date_format($value, $dateFormatString);
+    return $date;
+  }
 }

--- a/src/Parse/ParsePush.php
+++ b/src/Parse/ParsePush.php
@@ -47,9 +47,9 @@ class ParsePush
       }
     }
     if (isset($data['push_time'])) {
-      $data['push_time'] = ParseClient::_encode(
-        $data['push_time'], false
-      )['iso'];
+      //Local push date format is different from iso format generally used in Parse
+      //Schedule does not work if date format not correct
+      $data['push_time'] = ParseClient::getLocalPushDateFormat($data['push_time']);
     }
     if (isset($data['expiration_time'])) {
       $data['expiration_time'] = ParseClient::_encode(


### PR DESCRIPTION
Fix datetime format used in Local Push Scheduling. 
According to Parse Rest doc, push_time should be an ISO 8601 date without a time zone, i.e. 2014-10-16T12:00:00.
But it was formatted as 2014-10-16T12:00:00.000Z, then Local Push Scheduling does not work.
