### PR TITLE
ParseInstallation query()

### DIFF
--- a/src/Parse/ParseInstallation.php
+++ b/src/Parse/ParseInstallation.php
@@ -14,5 +14,11 @@ class ParseInstallation extends ParseObject
 {
 
   public static $parseClassName = "_Installation";
+  function void query(){
+    /*******
+     *
+     * Something goes here
+     */
+  } 
 
 }


### PR DESCRIPTION
 Call to undefined method ParseInstallation::query()
