### PR TITLE
includeKey() in ParseQuery is not returning the current object

### DIFF
--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -758,6 +758,7 @@ class ParseQuery
     } else {
       $this->includes[] = $key;
     }
+    return $this;
   }
 
   /**


### PR DESCRIPTION
It adds the key to the includes array but not retuning the current instance of ParseQuery. This breaks the method chaining.
