### PR TITLE
Fix to register ParseUser Subclass

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -1154,7 +1154,7 @@ class ParseObject implements Encodable
   public static function registerSubclass()
   {
     if (isset(static::$parseClassName)) {
-      if (!in_array(static::$parseClassName, self::$registeredSubclasses)) {
+      if (!array_key_exists(static::$parseClassName, self::$registeredSubclasses)) {
         self::$registeredSubclasses[static::$parseClassName] =
           get_called_class();
       }


### PR DESCRIPTION
Currently it's not possible to register a subclass for the ParseUser class.
In the current implementation the initialize function of the ParseClient client class will overwrite any registerSubclass action for ParseUser, ParseRole and ParseInstallation.

I didn't test the implementation intensely, but so far it's working.
