### PR TITLE
Always use '&' instead of relying on ini for query strings.

### DIFF
--- a/src/Parse/HttpClients/ParseCurlHttpClient.php
+++ b/src/Parse/HttpClients/ParseCurlHttpClient.php
@@ -178,7 +178,7 @@ class ParseCurlHttpClient implements ParseHttpable
 
         if($method == "GET" && !empty($data)) {
             // handle get
-            $url .= '?'.http_build_query($data);
+            $url .= '?'.http_build_query($data, null, '&');
 
         } else if($method == "POST") {
             // handle post

--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -365,7 +365,7 @@ class ParseQuery
             $queryOptions['where'] = json_encode($queryOptions['where']);
         }
 
-        return http_build_query($queryOptions);
+        return http_build_query($queryOptions, null, '&');
     }
 
     /**


### PR DESCRIPTION
parse server will fail if it receives a query string encoded with `&amp;`

if a php.ini is set to use `&amp;` then this lib will fail.

this pr changes `http_build_request` to always use `&` to separate query parameters elements.

note that this just makes the usage consistent as https://github.com/parse-community/parse-php-sdk/blob/cd27a867c28c46b965f04d5f30535c402fe9d993/src/Parse/HttpClients/ParseStreamHttpClient.php#L196 already sets the separator.

