### PR TITLE
Add getters to ParseInstallation

### DIFF
--- a/src/Parse/ParseInstallation.php
+++ b/src/Parse/ParseInstallation.php
@@ -10,4 +10,148 @@ namespace Parse;
 class ParseInstallation extends ParseObject
 {
     public static $parseClassName = '_Installation';
+
+    /**
+     * Gets the installation id for this installation
+     *
+     * @return string
+     */
+    public function getInstallationId()
+    {
+        return $this->get('installationId');
+
+    }
+
+    /**
+     * Gets the device token for this installation
+     *
+     * @return string
+     */
+    public function getDeviceToken()
+    {
+        return $this->get('deviceToken');
+
+    }
+
+    /**
+     * Get channels for this installation
+     *
+     * @return array
+     */
+    public function getChannels()
+    {
+        return $this->get('channels');
+
+    }
+
+    /**
+     * Gets the device type of this installation
+     *
+     * @return string
+     */
+    public function getDeviceType()
+    {
+        return $this->get('deviceType');
+
+    }
+
+    /**
+     * Gets the push type of this installation
+     *
+     * @return string
+     */
+    public function getPushType()
+    {
+        return $this->get('pushType');
+
+    }
+
+    /**
+     * Gets the GCM sender id of this installation
+     *
+     * @return string
+     */
+    public function getGCMSenderId()
+    {
+        return $this->get('GCMSenderId');
+
+    }
+
+    /**
+     * Gets the time zone of this installation
+     *
+     * @return string
+     */
+    public function getTimeZone()
+    {
+        return $this->get('timeZone');
+
+    }
+
+    /**
+     * Gets the locale id for this installation
+     *
+     * @return string
+     */
+    public function getLocaleIdentifier()
+    {
+        return $this->get('localeIdentifier');
+
+    }
+
+    /**
+     * Gets the badge number of this installation
+     *
+     * @return int
+     */
+    public function getBadge()
+    {
+        return $this->get('badge');
+
+    }
+
+    /**
+     * Gets the app version of this installation
+     *
+     * @return string
+     */
+    public function getAppVersion()
+    {
+        return $this->get('appVersion');
+
+    }
+
+    /**
+     * Get the app name for this installation
+     *
+     * @return string
+     */
+    public function getAppName()
+    {
+        return $this->get('appName');
+
+    }
+
+    /**
+     * Gets the app identifier for this installation
+     *
+     * @return string
+     */
+    public function getAppIdentifier()
+    {
+        return $this->get('appIdentifier');
+
+    }
+
+    /**
+     * Gets the parse version for this installation
+     *
+     * @return string
+     */
+    public function getParseVersion()
+    {
+        return $this->get('parseVersion');
+
+    }
+
 }

--- a/tests/Parse/ParseInstallationTest.php
+++ b/tests/Parse/ParseInstallationTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 4/13/17
+ * Time: 20:37
+ */
+
+namespace Parse\Test;
+
+
+use Parse\ParseException;
+use Parse\ParseInstallation;
+use Parse\ParseSchema;
+use Parse\ParseUser;
+
+class ParseInstallationTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        Helper::setUp();
+    }
+
+    /**
+     * @group installation-tests
+     */
+    public function testMissingIdentifyingField()
+    {
+        $this->setExpectedException(ParseException::class,
+            'at least one ID field (deviceToken, installationId) must be specified in this operation');
+
+        (new ParseInstallation())->save();
+    }
+
+    /**
+     * @group installation-tests
+     */
+    public function testMissingDeviceType()
+    {
+        $this->setExpectedException(ParseException::class,
+            'deviceType must be specified in this operation');
+
+        $installation = new ParseInstallation();
+        $installation->set('deviceToken', '12345');
+        $installation->save();
+
+    }
+
+    /**
+     * @group installation-tests
+     */
+    public function testClientsCannotFindWithoutMasterKey()
+    {
+        $this->setExpectedException(ParseException::class,
+            'Clients aren\'t allowed to perform the find operation on the installation collection.');
+
+        $query = ParseInstallation::query();
+        $query->first();
+
+    }
+
+    /**
+     * @group installation-tests
+     */
+    public function testInstallation()
+    {
+        $installationId = '12345';
+        $deviceToken    = 'device-token';
+        $deviceType     = 'android';
+        $channels       = [
+            'one',
+            'zwei',
+            'tres'
+        ];
+        $pushType       = 'a-push-type';
+        $GCMSenderId    = 'gcm-sender-id';
+        $timeZone       = 'Time/Zone';
+        $localeIdentifier = 'locale';
+        $badge          = 32;
+        $appVersion     = '1.0.0';
+        $appName        = 'Foo Bar App';
+        $appIdentifier  = 'foo-bar-app-id';
+        $parseVersion   = '1.2.3';
+
+        $installation = new ParseInstallation();
+        $installation->set('installationId', $installationId);
+        $installation->set('deviceToken', $deviceToken);
+        $installation->setArray('channels', $channels);
+        $installation->set('deviceType', $deviceType);
+        $installation->set('pushType', $pushType);
+        $installation->set('GCMSenderId', $GCMSenderId);
+        $installation->set('timeZone', $timeZone);
+        $installation->set('localeIdentifier', $localeIdentifier);
+        $installation->set('badge', $badge);
+        $installation->set('appVersion', $appVersion);
+        $installation->set('appName', $appName);
+        $installation->set('appIdentifier', $appIdentifier);
+        $installation->set('parseVersion', $parseVersion);
+
+        $installation->save();
+
+        // query for this installation now
+        $query = ParseInstallation::query();
+        $inst = $query->first(true);
+
+        $this->assertNotNull($inst, 'Installation not found');
+
+        $this->assertEquals($inst->getInstallationId(), $installationId);
+        $this->assertEquals($inst->getDeviceToken(), $deviceToken);
+        $this->assertEquals($inst->getChannels(), $channels);
+        $this->assertEquals($inst->getDeviceType(), $deviceType);
+        $this->assertEquals($inst->getPushType(), $pushType);
+        $this->assertEquals($inst->getGCMSenderId(), $GCMSenderId);
+        $this->assertEquals($inst->getTimeZone(), $timeZone);
+        $this->assertEquals($inst->getLocaleIdentifier(), $localeIdentifier);
+        $this->assertEquals($inst->getBadge(), $badge);
+        $this->assertEquals($inst->getAppVersion(), $appVersion);
+        $this->assertEquals($inst->getAppName(), $appName);
+        $this->assertEquals($inst->getAppIdentifier(), $appIdentifier);
+        $this->assertEquals($inst->getParseVersion(), $parseVersion);
+
+        // cleanup
+        $installation->destroy();
+
+    }
+
+}

--- a/tests/Parse/ParseInstallationTest.php
+++ b/tests/Parse/ParseInstallationTest.php
@@ -1,24 +1,21 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Bfriedman
- * Date: 4/13/17
- * Time: 20:37
- */
 
 namespace Parse\Test;
 
 
 use Parse\ParseException;
 use Parse\ParseInstallation;
-use Parse\ParseSchema;
-use Parse\ParseUser;
 
 class ParseInstallationTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
         Helper::setUp();
+    }
+
+    public function tearDown()
+    {
+        Helper::clearClass(ParseInstallation::$parseClassName);
     }
 
     /**
@@ -56,6 +53,24 @@ class ParseInstallationTest extends \PHPUnit_Framework_TestCase
 
         $query = ParseInstallation::query();
         $query->first();
+
+    }
+
+    /**
+     * @group installation-tests
+     */
+    public function testClientsCannotDestroyWithoutMasterKey()
+    {
+        $installation = new ParseInstallation();
+        $installation->set('deviceToken', '12345');
+        $installation->set('deviceType', 'android');
+        $installation->save();
+
+        $this->setExpectedException(ParseException::class,
+            "Clients aren't allowed to perform the delete operation on the installation collection.");
+
+        // try destroying, without using the master key
+        $installation->destroy();
 
     }
 
@@ -120,7 +135,7 @@ class ParseInstallationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($inst->getParseVersion(), $parseVersion);
 
         // cleanup
-        $installation->destroy();
+        $installation->destroy(true);
 
     }
 


### PR DESCRIPTION
Fleshes out the `ParseInstallation` class with getters to standardize readable properties. Previous to this the class was simply a stub, leaving it up to the developer to recall the correct keys to fetch. In this fashion it's a bit more explicit what data is expected to be available.

This does _not_ add setters as the php sdk is intended to be reading `_Installation`, rather than writing to it. However this does not change the fact that working with the **masterKey** one can create and modify installations from this sdk as they see fit.