### PR TITLE
Added methods to ParsePushStatus for checking push status

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,20 +284,24 @@ if(ParsePush::hasStatus($response)) {
 
     // Retrieve PushStatus object
     $pushStatus = ParsePush::getStatus($response);
-    
-    // get push status string
-    $status = $pushStatus->getPushStatus();
-    
-    if($status == "succeeded") {
-        // handle a successful push request
-        
-    } else if($status == "running") {
+
+    // check push status
+    if($pushStatus->isPending()) {
+        // handle a pending push request
+
+    } else if($pushStatus->isRunning()) {
         // handle a running push request
-        
-    } else if($status == "failed") {
-        // push request did not succeed
-        
+
+    } else if($pushStatus->hasSucceeded()) {
+        // handle a successful push request
+
+    } else if($pushStatus->hasFailed()) {
+        // handle a failed request
+
     }
+    
+    // ...or get the push status string to check yourself
+    $status = $pushStatus->getPushStatus();
     
     // get # pushes sent
     $sent = $pushStatus->getPushesSent();

--- a/src/Parse/ParsePushStatus.php
+++ b/src/Parse/ParsePushStatus.php
@@ -116,7 +116,7 @@ class ParsePushStatus extends ParseObject
      */
     public function isScheduled()
     {
-        return $this->getPushStatus() == self::STATUS_SCHEDULED;
+        return $this->getPushStatus() === self::STATUS_SCHEDULED;
 
     }
 
@@ -127,7 +127,7 @@ class ParsePushStatus extends ParseObject
      */
     public function isPending()
     {
-        return $this->getPushStatus() == self::STATUS_PENDING;
+        return $this->getPushStatus() === self::STATUS_PENDING;
 
     }
 
@@ -138,7 +138,7 @@ class ParsePushStatus extends ParseObject
      */
     public function isRunning()
     {
-        return $this->getPushStatus() == self::STATUS_RUNNING;
+        return $this->getPushStatus() === self::STATUS_RUNNING;
 
     }
 
@@ -149,7 +149,7 @@ class ParsePushStatus extends ParseObject
      */
     public function hasSucceeded()
     {
-        return $this->getPushStatus() == self::STATUS_SUCCEEDED;
+        return $this->getPushStatus() === self::STATUS_SUCCEEDED;
 
     }
 
@@ -160,7 +160,7 @@ class ParsePushStatus extends ParseObject
      */
     public function hasFailed()
     {
-        return $this->getPushStatus() == self::STATUS_FAILED;
+        return $this->getPushStatus() === self::STATUS_FAILED;
 
     }
 

--- a/src/Parse/ParsePushStatus.php
+++ b/src/Parse/ParsePushStatus.php
@@ -11,6 +11,17 @@ class ParsePushStatus extends ParseObject
 {
     public static $parseClassName = '_PushStatus';
 
+    // possible push status values from parse server
+    const STATUS_SCHEDULED  = 'scheduled';
+    const STATUS_PENDING    = 'pending';
+    const STATUS_RUNNING    = 'running';
+    const STATUS_SUCCEEDED  = 'succeeded';
+    const STATUS_FAILED     = 'failed';
+
+    /**
+     * 'scheduled', 'pending', etc. Add constants and 'isPending' and such for better status checking
+     */
+
     /**
      * Returns a push status object or null from an id
      *
@@ -95,6 +106,61 @@ class ParsePushStatus extends ParseObject
     public function getPushStatus()
     {
         return $this->get("status");
+
+    }
+
+    /**
+     * Indicates whether this push is scheduled
+     *
+     * @return bool
+     */
+    public function isScheduled()
+    {
+        return $this->getPushStatus() == self::STATUS_SCHEDULED;
+
+    }
+
+    /**
+     * Indicates whether this push is pending
+     *
+     * @return bool
+     */
+    public function isPending()
+    {
+        return $this->getPushStatus() == self::STATUS_PENDING;
+
+    }
+
+    /**
+     * Indicates whether this push is running
+     *
+     * @return bool
+     */
+    public function isRunning()
+    {
+        return $this->getPushStatus() == self::STATUS_RUNNING;
+
+    }
+
+    /**
+     * Indicates whether this push has succeeded
+     *
+     * @return bool
+     */
+    public function hasSucceeded()
+    {
+        return $this->getPushStatus() == self::STATUS_SUCCEEDED;
+
+    }
+
+    /**
+     * Indicates whether this push has failed
+     *
+     * @return bool
+     */
+    public function hasFailed()
+    {
+        return $this->getPushStatus() == self::STATUS_FAILED;
 
     }
 

--- a/tests/Parse/ParsePushTest.php
+++ b/tests/Parse/ParsePushTest.php
@@ -123,10 +123,10 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
     {
         ParsePush::send(
             [
-            'data'            => ['alert' => 'iPhone 5 is out!'],
-            'push_time'       => new \DateTime(),
-            'expiration_time' => new \DateTime(),
-            'channels'        => [],
+                'data'            => ['alert' => 'iPhone 5 is out!'],
+                'push_time'       => new \DateTime(),
+                'expiration_time' => new \DateTime(),
+                'channels'        => [],
             ]
         , true);
     }
@@ -215,9 +215,17 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("rest", $pushStatus->getPushSource(),
             'Source was not rest');
 
+        // verify not scheduled
+        $this->assertFalse($pushStatus->isScheduled());
+
+        // verify not pending
+        $this->assertFalse($pushStatus->isPending());
+
         // verify 'running'
-        $this->assertEquals("running", $pushStatus->getPushStatus(),
+        $this->assertTrue($pushStatus->isRunning(),
             'Push did not succeed');
+
+
 
         // verify # sent & failed
         $this->assertEquals(0, $pushStatus->getPushesSent(),
@@ -227,6 +235,10 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotNull($pushStatus->getPushHash(),
             'Hash not present');
+
+        // verify we have neither failed or succeeded
+        $this->assertFalse($pushStatus->hasFailed());
+        $this->assertFalse($pushStatus->hasSucceeded());
 
     }
 


### PR DESCRIPTION
Adds methods to `ParsePushStatus` to handle checking the current status of a recent push request.

Prior to this checking push status involved extracting the status string and checking it's value to infer the status. Considering that the values never change this cements them as constants in `ParsePushStatus` and provides methods like `isRunning` and `hasSucceeded` for a more convenient means of checking status.

Updates tests & the README example to use these new methods instead of checking the status string by hand.