### PR TITLE
Update composer to point to parse-community

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ into a single commit. Please provide ample explanation in the commit message.
 Installation
 ------------
 
-Testing the Parse PHP SDK requires having a working Parse Server instance to run against. 
+Testing the Parse PHP SDK requires having a working Parse Server instance to run against.
 Additionally you'll need to add some cloud code to it.
 
 To get started:
@@ -22,7 +22,7 @@ To get started:
 From here you have to setup an instance of parse server.
 
 To get started quickly you can clone and run this [parse server test] project.
-It's setup with the appropriate configuration to run the php sdk test suite. 
+It's setup with the appropriate configuration to run the php sdk test suite.
 Additionally it handles setting up mongodb for the server.
 
 Alternately you can configure a compatible test server as follows:
@@ -71,4 +71,4 @@ If you have XDebug setup and can view code coverage please ensure that you do yo
 [Create Parse App]: https://parse.com/apps/new
 [XDebug]: https://xdebug.org/
 [parse server test]: https://github.com/montymxb/parse-server-test
-[Setup a local Parse Server instance]: https://github.com/ParsePlatform/parse-server#user-content-locally
+[Setup a local Parse Server instance]: https://github.com/parse-community/parse-server#user-content-locally

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Parse PHP SDK
 -------------
 
 The Parse PHP SDK gives you access to the powerful Parse cloud platform
-from your PHP app or script.  Updated to work with the self-hosted Parse Server: https://github.com/parseplatform/parse-server
+from your PHP app or script.  Updated to work with the self-hosted Parse Server: https://github.com/parse-community/parse-server
 
 Installation
 ------------
@@ -76,7 +76,7 @@ Setting the http client can be done as follows:
 ParseClient::setHttpClient(new ParseCurlHttpClient());
 
 // set stream http client
-// ** requires 'allow_url_fopen' to be enabled in php.ini ** 
+// ** requires 'allow_url_fopen' to be enabled in php.ini **
 ParseClient::setHttpClient(new ParseStreamHttpClient());
 ```
 
@@ -299,16 +299,16 @@ if(ParsePush::hasStatus($response)) {
         // handle a failed request
 
     }
-    
+
     // ...or get the push status string to check yourself
     $status = $pushStatus->getPushStatus();
-    
+
     // get # pushes sent
     $sent = $pushStatus->getPushesSent();
-    
+
     // get # pushes failed
     $failed = $pushStatus->getPushesFailed();
-    
+
 }
 ```
 
@@ -323,4 +323,4 @@ the Parse PHP SDK. We welcome fixes and enhancements.
 
 -----
 
-As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code. 
+As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code.

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "Parse PHP SDK",
     "keywords": ["parse", "sdk"],
     "type": "library",
-    "homepage": "https://github.com/parseplatform/parse-php-sdk",
+    "homepage": "https://github.com/parse-community/parse-php-sdk",
     "license": "Parse Platform License",
     "authors": [
         {
             "name": "Parse",
-            "homepage": "https://github.com/parseplatform/parse-php-sdk/contributors"
+            "homepage": "https://github.com/parse-community/parse-php-sdk/graphs/contributors"
         }
     ],
     "require": {
@@ -29,11 +29,6 @@
     "autoload-dev": {
         "psr-4": {
             "Parse\\Test\\": "tests/Parse/"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.1-dev"
         }
     }
 }


### PR DESCRIPTION
disclaimer: I haven't used composer in years :).

I updated my composer.json to have:

 `"parse/php-sdk": "^1.2.7",`

when i run `composer update --ignore-platform-reqs parse/php-sdk`

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.


  Problem 1
    - The requested package parse/php-sdk ^1.2.7 exists as parse/php-sdk[1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.1.0, 1.1.1, 1.1.10, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.1.6, 1.1.7, 1.1.8, 1.1.9, 1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.2.5, dev-master, 1.1.x-dev, dev-consistent-appersand-in-urls] but these are rejected by your constraint.
```
I don't think that this pr will fix the problem, but figure should be fixed anyway?!?