### PR TITLE
修复ParseQuery::find方法中由于ParseClient::_request返回false引发的报错"Invalid argument supplied for foreach()"

### DIFF
--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -417,7 +417,7 @@ class ParseQuery
             $useMasterKey
         );
 		
-		if (!is_array($result)) return false;
+        if (!is_array($result)) return false;
 
         $output = [];
         foreach ($result['results'] as $row) {

--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -416,6 +416,9 @@ class ParseQuery
             null,
             $useMasterKey
         );
+		
+		if (!is_array($result)) return false;
+
         $output = [];
         foreach ($result['results'] as $row) {
             $obj = ParseObject::create($this->className, $row['objectId']);


### PR DESCRIPTION
最近在项目中频繁报错“Invalid argument supplied for foreach()”，调试发现ParseQuery类的find方法中使用了ParseClient::_request，且在失败情况下返回false或者throw new ParseException，然后foreach直接报错了。所以加个健壮性判断即可，哈哈，至于为啥是两个commits，是因为我本地编辑器的tab和空格问题，惭愧~~