### PR TITLE
Added check for invalid responses which are not empty.

### DIFF
--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -493,6 +493,12 @@ final class ParseClient
         }
 
         $decoded = json_decode($response, true);
+
+        if(!isset($decoded) && $response !== '') {
+            throw new ParseException('Bad Request. Could not decode Response', -1);
+
+        }
+
         if (isset($decoded['error'])) {
             // check to convert error to a string, if an array
             // used to handle an Array 'error' from back4app.com

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -495,7 +495,11 @@ final class ParseClient
         $decoded = json_decode($response, true);
 
         if(!isset($decoded) && $response !== '') {
-            throw new ParseException('Bad Request. Could not decode Response', -1);
+            throw new ParseException(
+                'Bad Request. Could not decode Response: '.
+                '('.json_last_error().') '.json_last_error_msg(),
+                -1
+            );
 
         }
 


### PR DESCRIPTION
This double checks whether a response from the server was decoded successfully. It additionally checks if there was any response to begin with, to avoid false positives on such operations as ParseFile deletion where no response is returned.

This is in regards to #307 , which has pointed out that **https://api.parse.com/** now returns a response indicating the service has shut down. This is returned as plain text, however the **Content-type** indicates **application/octet-stream**. As a result the sdk tries to process the request to no avail. 

Although noone should be using the old api, this makes a point that the sdk could try to run after an invalid response with the 'right' content type. This change prevents that from occurring.

This does _not_ add tests, as this is an unlikely error in how the sdk handles responses. That and the resulting tests would have to target the old api to replicate this, and that may very well be corrected at some point in the future.