### PR TITLE
Propagate $useMasterKey to ParseFile when saving ParseObject

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -987,7 +987,7 @@ class ParseObject implements Encodable
         }
 
         foreach ($unsavedFiles as &$file) {
-            $file->save();
+            $file->save($useMasterKey);
         }
 
         $objects = [];


### PR DESCRIPTION
Just a small fix to send `$useMasterKey` to `ParseFile::save()`