### PR TITLE
Updates various tests.

### DIFF
--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -111,7 +111,7 @@ final class ParseClient
      *
      * @var string
      */
-    const VERSION_STRING = 'php1.2.2';
+    const VERSION_STRING = 'php1.2.7';
 
     /**
      * Parse\Client::initialize, must be called before using Parse features.

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -514,7 +514,8 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         $httpClient = ParseClient::getHttpClient();
 
         // create a mock of the current http client
-        $stubClient = $this->createMock(get_class($httpClient));
+        $stubClient = $this->getMockBuilder(get_class($httpClient))
+            ->getMock();
 
         // stub the response type to return
         // something we will try to work with

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -1499,20 +1499,23 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @group order-by-updated-at
+     */
     public function testOrderByUpdatedAtAsc()
     {
         $numbers = [3, 1, 2];
         $objects = [];
-        $this->saveObjects(
-            3,
-            function ($i) use ($numbers, &$objects) {
-                $obj = ParseObject::create('TestObject');
-                $obj->set('number', $numbers[$i]);
-                $objects[] = $obj;
 
-                return $obj;
-            }
-        );
+        foreach($numbers as $num) {
+            $obj = ParseObject::create('TestObject');
+            $obj->set('number', $num);
+            $obj->save();
+            $objects[]  = $obj;
+            sleep(1);
+
+        }
+
         $objects[1]->set('number', 4);
         $objects[1]->save();
         $query = new ParseQuery('TestObject');
@@ -1541,16 +1544,16 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
     {
         $numbers = [3, 1, 2];
         $objects = [];
-        $this->saveObjects(
-            3,
-            function ($i) use ($numbers, &$objects) {
-                $obj = ParseObject::create('TestObject');
-                $obj->set('number', $numbers[$i]);
-                $objects[] = $obj;
 
-                return $obj;
-            }
-        );
+        foreach($numbers as $num) {
+            $obj = ParseObject::create('TestObject');
+            $obj->set('number', $num);
+            $obj->save();
+            $objects[]  = $obj;
+            sleep(1);
+
+        }
+
         $objects[1]->set('number', 4);
         $objects[1]->save();
         $query = new ParseQuery('TestObject');
@@ -1561,7 +1564,8 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
             count($results),
             'Did not return correct number of objects.'
         );
-        $expected = [4, 3, 2];
+
+        $expected = [4, 2, 3];
         for ($i = 0; $i < 3; ++$i) {
             $this->assertEquals(
                 $expected[$i],


### PR DESCRIPTION
In reference to #312.

Updates a mocking test to utilize phpunit 4's approach to mocking objects. This looks to be forward compatible with later versions as well, meaning we can upgrade to a currently supported version of phpunit when we feel the need.

Updates a pair of test cases in **ParseQueryTest** with a small time delay so that updatedAt based queries will return as expected. Prior to this both test cases attempted would save all objects in one `ParseObject::saveAll` call. This could lead to the update times being identical potentially, and the objects could return in an flip-flop fashion in regards to order.

Also noticed that one of the aforementioned Query tests was checking for objects in the _wrong_ order. This was possible given the ambiguous time sorting of objects, which had the same update times.

@acinader if you can verify these changes have the intended effect on your end I would appreciate it!