### PR TITLE
PFObject associativeArray to _encode fix

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -907,6 +907,8 @@ class ParseObject implements Encodable
         foreach ($this->estimatedData as $key => $value) {
             if (is_object($value) && $value instanceof Encodable) {
                 $out[$key] = $value->_encode();
+            } elseif (self::isAssoc($value)) {
+                $out[$key] = $value;
             } elseif (is_array($value)) {
                 $out[$key] = [];
                 foreach ($value as $item) {
@@ -934,7 +936,7 @@ class ParseObject implements Encodable
         $this->beforeSave();
         return ParseClient::_encode($this->operationSet, true);
     }
-    
+
     /**
      * Before save stub
      *
@@ -1366,5 +1368,19 @@ class ParseObject implements Encodable
         } else {
             return new ParseQuery($subclass);
         }
+    }
+
+    /**
+     * Check if array is Associative
+     * Array is not associative is keys are numeric
+     *
+     * @return bool
+     */
+    private static function isAssoc($arr)
+    {
+        if (array() === $arr || !is_array($arr)) {
+            return false;
+        }
+        return array_keys($arr) !== range(0, count($arr) - 1);
     }
 }

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -907,15 +907,13 @@ class ParseObject implements Encodable
         foreach ($this->estimatedData as $key => $value) {
             if (is_object($value) && $value instanceof Encodable) {
                 $out[$key] = $value->_encode();
-            } elseif (self::isAssoc($value)) {
-                $out[$key] = $value;
             } elseif (is_array($value)) {
                 $out[$key] = [];
-                foreach ($value as $item) {
+                foreach ($value as $itemKey => $item) {
                     if (is_object($item) && $item instanceof Encodable) {
-                        $out[$key][] = $item->_encode();
+                        $out[$key][$itemKey] = $item->_encode();
                     } else {
-                        $out[$key][] = $item;
+                        $out[$key][$itemKey] = $item;
                     }
                 }
             } else {
@@ -1368,19 +1366,5 @@ class ParseObject implements Encodable
         } else {
             return new ParseQuery($subclass);
         }
-    }
-
-    /**
-     * Check if array is Associative
-     * Array is not associative is keys are numeric
-     *
-     * @return bool
-     */
-    private static function isAssoc($arr)
-    {
-        if (array() === $arr || !is_array($arr)) {
-            return false;
-        }
-        return array_keys($arr) !== range(0, count($arr) - 1);
     }
 }

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -728,6 +728,29 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($decoded->foo));
     }
 
+    public function testAssocToJSONSavedObject()
+    {
+        $obj = ParseObject::create('TestObject');
+        $assoc = ["foo" => "bar", "baz" => "yay"];
+        $obj->setAssociativeArray('obj', $assoc);
+        $obj->save();
+        $json = $obj->_encode();
+        $decoded = json_decode($json, true);
+        $this->assertEquals($decoded['obj'], $assoc);
+        $this->assertEquals($obj->get('obj'), $assoc);
+    }
+
+    public function testAssocToJSONUnsavedObject()
+    {
+        $obj = ParseObject::create('TestObject');
+        $assoc = ["foo" => "bar", "baz" => "yay"];
+        $obj->setAssociativeArray('obj', $assoc);
+        $json = $obj->_encode();
+        $decoded = json_decode($json, true);
+        $this->assertEquals($decoded['obj'], $assoc);
+        $this->assertEquals($obj->get('obj'), $assoc);
+    }
+
     public function testRemoveOperation()
     {
         $obj = ParseObject::create('TestObject');
@@ -1229,7 +1252,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         );
         $obj = new ParseObject('TestClass');
         $obj->set('key', ['is-an-array' => 'yes']);
-        
+
     }
 
     public function testSetArrayNullKey()


### PR DESCRIPTION
I have a issue when encode / decode an Associative array and received a sequential array.

This PR fixes this issue.

I don't know much about writing test code or PR's so any help would be great