### PR TITLE
Updates 'npm stop' to properly run

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start" : "./node_modules/parse-server-test/run-server",
-    "stop"  : "mongodb-runner stop"
+    "stop"  : "./node_modules/parse-server-test/stop-server"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The package.json **npm start** command calls down to the `run-server` script in the **parse-server-test** dependency (from npm). 

Following that this modifies package.json to call the shutdown script in **parse-server-test** as well for **npm stop**, which properly stops the internal server and mongodb instances spun up for testing purposes.