### PR TITLE
Update PHP_CodeSniffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ logs
 phpunit-test-results
 
 *.log
+
+coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ logs
 
 # ignore test results
 phpunit-test-results
+
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,15 @@ php:
 #  - nightly
 before_install:
   - nvm install 6.11
-install: 
+install:
   - composer install
   - npm install
 before_script:
   - npm start 1>&2
   - sleep 3
+  - npm run lint
 script:
-    - ./vendor/bin/phpunit --coverage-clover=coverage.xml
+    - npm run test:coverage
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,11 +69,11 @@ You may also run tests directly using phpunit as follows:
 
     npm test
 
-Make sure your code is linted with phpcs (PSR-2 Coding Style)
+Make sure your code is linted with phpcs ([PSR-2 Coding Style]):
 
     npm run lint
 
-You can automatically fix lint errors with phpcbf
+You can automatically fix lint errors with phpcbf:
 
     npm run lint:fix
 
@@ -91,3 +91,5 @@ If you have XDebug setup and can view code coverage please ensure that you do yo
 [XDebug]: https://xdebug.org/
 [parse server test]: https://github.com/montymxb/parse-server-test
 [Setup a local Parse Server instance]: https://github.com/parse-community/parse-server#user-content-locally
+[PSR-2 Coding Style]: http://www.php-fig.org/psr/psr-2/
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Make sure your code is linted with phpcs
 
 You can automatically fix lint errors with phpcbf
 
-    `npm run lint-fix`
+    `npm run lint:fix`
 
 The test suite is setup for code coverage if you have [XDebug] installed and setup.
 Coverage is outputted as text and as html in the phpunit-test-results/ directory within the project root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,15 +63,19 @@ Alternately you can configure a compatible test server as follows:
 
 You should now be able to execute the tests, from project root folder:
 
-    `npm test`
+    ./vendor/bin/phpunit
+
+You may also run tests directly using phpunit as follows:
+
+    npm test
 
 Make sure your code is linted with phpcs (PSR-2 Coding Style)
 
-    `npm run lint`
+    npm run lint
 
 You can automatically fix lint errors with phpcbf
 
-    `npm run lint:fix`
+    npm run lint:fix
 
 The test suite is setup for code coverage if you have [XDebug] installed and setup.
 Coverage is outputted as text and as html in the phpunit-test-results/ directory within the project root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ To setup the Test Parse Server:
 * Run `npm install` from the project root to download the server and it's dependencies.
 * When you're ready to run tests use `npm start` from the project root to boot up the test server.
 
-The embedded test server utilizes this [parse server test] project. 
+The embedded test server utilizes this [parse server test] project.
 It's setup with the appropriate configuration to run the php sdk test suite.
 Additionally it handles setting up mongodb for the server.
 
@@ -63,7 +63,15 @@ Alternately you can configure a compatible test server as follows:
 
 You should now be able to execute the tests, from project root folder:
 
-    ./vendor/bin/phpunit
+    `npm test`
+
+Make sure your code is linted with phpcs
+
+    `npm run lint`
+
+You can automatically fix lint errors with phpcbf
+
+    `npm run lint-fix`
 
 The test suite is setup for code coverage if you have [XDebug] installed and setup.
 Coverage is outputted as text and as html in the phpunit-test-results/ directory within the project root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ You should now be able to execute the tests, from project root folder:
 
     `npm test`
 
-Make sure your code is linted with phpcs
+Make sure your code is linted with phpcs (PSR-2 Coding Style)
 
     `npm run lint`
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "squizlabs/php_codesniffer": "~1.5",
+        "squizlabs/php_codesniffer": "^3.0.1",
         "phpdocumentor/phpdocumentor": "~2.5"
     },
     "autoload": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "parse-php-sdk",
   "scripts": {
     "test": "./vendor/bin/phpunit",
+    "test:coverage": "./vendor/bin/phpunit --coverage-clover=coverage.xml",
     "lint": "./vendor/bin/phpcs --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
-    "lint-fix": "./vendor/bin/phpcbf --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
+    "lint:fix": "./vendor/bin/phpcbf --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "start" : "./node_modules/parse-server-test/run-server",
     "stop"  : "./node_modules/parse-server-test/stop-server"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "parse-php-sdk",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "./vendor/bin/phpunit",
+    "lint": "./vendor/bin/phpcs --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
+    "lint-fix": "./vendor/bin/phpcbf --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "start" : "./node_modules/parse-server-test/run-server",
     "stop"  : "./node_modules/parse-server-test/stop-server"
   },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="phpcsignore">
+ <description>PHPCS Ignore Rule</description>
+ <rule ref="PSR2" />
+ <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+   <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.MethodDeclaration">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+  <severity>0</severity>
+ </rule>
+</ruleset>

--- a/src/Parse/HttpClients/ParseCurl.php
+++ b/src/Parse/HttpClients/ParseCurl.php
@@ -7,7 +7,6 @@
 
 namespace Parse\HttpClients;
 
-
 use Parse\ParseException;
 
 /**
@@ -27,11 +26,9 @@ class ParseCurl
      */
     public function init()
     {
-        if($this->curl === null) {
+        if ($this->curl === null) {
             $this->curl = curl_init();
-
         }
-
     }
 
     /**
@@ -42,9 +39,8 @@ class ParseCurl
      */
     public function exec()
     {
-        if(!isset($this->curl)) {
+        if (!isset($this->curl)) {
             throw new ParseException('You must call ParseCurl::init first');
-
         }
 
         return curl_exec($this->curl);
@@ -59,13 +55,11 @@ class ParseCurl
      */
     public function setOption($option, $value)
     {
-        if(!isset($this->curl)) {
+        if (!isset($this->curl)) {
             throw new ParseException('You must call ParseCurl::init first');
-
         }
 
         curl_setopt($this->curl, $option, $value);
-
     }
 
     /**
@@ -76,13 +70,11 @@ class ParseCurl
      */
     public function setOptionsArray($options)
     {
-        if(!isset($this->curl)) {
+        if (!isset($this->curl)) {
             throw new ParseException('You must call ParseCurl::init first');
-
         }
 
         curl_setopt_array($this->curl, $options);
-
     }
 
     /**
@@ -94,13 +86,11 @@ class ParseCurl
      */
     public function getInfo($info)
     {
-        if(!isset($this->curl)) {
+        if (!isset($this->curl)) {
             throw new ParseException('You must call ParseCurl::init first');
-
         }
 
         return curl_getinfo($this->curl, $info);
-
     }
 
     /**
@@ -111,13 +101,11 @@ class ParseCurl
      */
     public function getError()
     {
-        if(!isset($this->curl)) {
+        if (!isset($this->curl)) {
             throw new ParseException('You must call ParseCurl::init first');
-
         }
 
         return curl_error($this->curl);
-
     }
 
     /**
@@ -128,13 +116,11 @@ class ParseCurl
      */
     public function getErrorCode()
     {
-        if(!isset($this->curl)) {
+        if (!isset($this->curl)) {
             throw new ParseException('You must call ParseCurl::init first');
-
         }
 
         return curl_errno($this->curl);
-
     }
 
     /**
@@ -142,9 +128,8 @@ class ParseCurl
      */
     public function close()
     {
-        if(!isset($this->curl)) {
+        if (!isset($this->curl)) {
             throw new ParseException('You must call ParseCurl::init first');
-
         }
 
         // close our handle
@@ -152,7 +137,5 @@ class ParseCurl
 
         // unset our curl handle
         $this->curl = null;
-
     }
-
 }

--- a/src/Parse/HttpClients/ParseCurlHttpClient.php
+++ b/src/Parse/HttpClients/ParseCurlHttpClient.php
@@ -7,7 +7,6 @@
 
 namespace Parse\HttpClients;
 
-
 use Parse\ParseException;
 
 /**
@@ -77,9 +76,8 @@ class ParseCurlHttpClient implements ParseHttpable
 
     public function __construct()
     {
-        if(!isset($this->parseCurl)) {
+        if (!isset($this->parseCurl)) {
             $this->parseCurl = new ParseCurl();
-
         }
     }
 
@@ -92,7 +90,6 @@ class ParseCurlHttpClient implements ParseHttpable
     public function addRequestHeader($key, $value)
     {
         $this->headers[$key]    = $value;
-
     }
 
     /**
@@ -104,13 +101,11 @@ class ParseCurlHttpClient implements ParseHttpable
     {
         // coalesce our header key/value pairs
         $headers = [];
-        foreach($this->headers as $key => $value) {
+        foreach ($this->headers as $key => $value) {
             $headers[] = $key.': '.$value;
-
         }
 
         return $headers;
-
     }
 
     /**
@@ -121,7 +116,6 @@ class ParseCurlHttpClient implements ParseHttpable
     public function getResponseHeaders()
     {
         return $this->responseHeaders;
-
     }
 
     /**
@@ -132,7 +126,6 @@ class ParseCurlHttpClient implements ParseHttpable
     public function getResponseStatusCode()
     {
         return $this->responseCode;
-
     }
 
     /**
@@ -143,7 +136,6 @@ class ParseCurlHttpClient implements ParseHttpable
     public function getResponseContentType()
     {
         return $this->responseContentType;
-
     }
 
     /**
@@ -161,7 +153,6 @@ class ParseCurlHttpClient implements ParseHttpable
             CURLOPT_SSL_VERIFYPEER  => true,
             CURLOPT_SSL_VERIFYHOST  => 2,
         ));
-
     }
 
     /**
@@ -176,34 +167,29 @@ class ParseCurlHttpClient implements ParseHttpable
     public function send($url, $method = 'GET', $data = array())
     {
 
-        if($method == "GET" && !empty($data)) {
+        if ($method == "GET" && !empty($data)) {
             // handle get
             $url .= '?'.http_build_query($data, null, '&');
-
-        } else if($method == "POST") {
+        } elseif ($method == "POST") {
             // handle post
             $this->parseCurl->setOptionsArray(array(
                 CURLOPT_POST        => 1,
                 CURLOPT_POSTFIELDS  => $data
             ));
-
-        } else if($method == "PUT") {
+        } elseif ($method == "PUT") {
             // handle put
             $this->parseCurl->setOptionsArray(array(
                 CURLOPT_CUSTOMREQUEST   => $method,
                 CURLOPT_POSTFIELDS      => $data
             ));
-
-        } else if($method == "DELETE") {
+        } elseif ($method == "DELETE") {
             // handle delete
             $this->parseCurl->setOption(CURLOPT_CUSTOMREQUEST, $method);
-
         }
 
-        if(count($this->headers) > 0) {
+        if (count($this->headers) > 0) {
             // set our custom request headers
             $this->parseCurl->setOption(CURLOPT_HTTPHEADER, $this->buildRequestHeaders());
-
         }
 
         // set url
@@ -239,7 +225,6 @@ class ParseCurlHttpClient implements ParseHttpable
         $this->headers = array();
 
         return $response;
-
     }
 
     /**
@@ -264,23 +249,19 @@ class ParseCurlHttpClient implements ParseHttpable
         // sepearate our header components
         $headerComponents = explode("\n", $rawHeaders);
 
-        foreach($headerComponents as $component) {
+        foreach ($headerComponents as $component) {
             if (strpos($component, ': ') === false) {
                 // set our http_code
                 $headers['http_code'] = $component;
-
-
             } else {
                 // set this header key/value pair
                 list($key, $value) = explode(': ', $component);
                 $headers[$key]      = $value;
-
             }
         }
 
         // return our completed headers
         return $headers;
-
     }
 
 
@@ -292,7 +273,6 @@ class ParseCurlHttpClient implements ParseHttpable
     public function setConnectionTimeout($timeout)
     {
         $this->parseCurl->setOption(CURLOPT_CONNECTTIMEOUT, $timeout);
-
     }
 
     /**
@@ -303,7 +283,6 @@ class ParseCurlHttpClient implements ParseHttpable
     public function setTimeout($timeout)
     {
         $this->parseCurl->setOption(CURLOPT_TIMEOUT, $timeout);
-
     }
 
     /**
@@ -315,7 +294,6 @@ class ParseCurlHttpClient implements ParseHttpable
     {
         // name of a file holding one or more certificates to verify the peer with
         $this->parseCurl->setOption(CURLOPT_CAINFO, $caFile);
-
     }
 
     /**
@@ -326,7 +304,6 @@ class ParseCurlHttpClient implements ParseHttpable
     public function getErrorCode()
     {
         return $this->curlErrorCode;
-
     }
 
     /**
@@ -337,7 +314,6 @@ class ParseCurlHttpClient implements ParseHttpable
     public function getErrorMessage()
     {
         return $this->curlErrorMessage;
-
     }
 
     /**
@@ -351,19 +327,15 @@ class ParseCurlHttpClient implements ParseHttpable
 
         // This corrects a Curl bug where header size does not account
         // for additional Proxy headers.
-        if ( $this->needsCurlProxyFix() ) {
-
+        if ($this->needsCurlProxyFix()) {
             // Additional way to calculate the request body size.
             if (preg_match('/Content-Length: (\d+)/', $this->response, $match)) {
                 $headerSize = mb_strlen($this->response) - $match[1];
-
             } elseif (stripos($this->response, self::CONNECTION_ESTABLISHED) !== false) {
                 $headerSize += mb_strlen(self::CONNECTION_ESTABLISHED);
-
             }
         }
         return $headerSize;
-
     }
 
     /**
@@ -378,7 +350,5 @@ class ParseCurlHttpClient implements ParseHttpable
         $version    = $versionDat['version_number'];
 
         return $version < self::CURL_PROXY_QUIRK_VER;
-
     }
-
 }

--- a/src/Parse/HttpClients/ParseHttpable.php
+++ b/src/Parse/HttpClients/ParseHttpable.php
@@ -7,7 +7,6 @@
 
 namespace Parse\HttpClients;
 
-
 interface ParseHttpable
 {
     /**
@@ -88,5 +87,4 @@ interface ParseHttpable
      * @return string
      */
     public function send($url, $method = 'GET', $data = array());
-
 }

--- a/src/Parse/HttpClients/ParseStream.php
+++ b/src/Parse/HttpClients/ParseStream.php
@@ -45,7 +45,6 @@ class ParseStream
     public function createContext($options)
     {
         $this->stream = stream_context_create($options);
-
     }
 
     /**
@@ -59,20 +58,17 @@ class ParseStream
         try {
             // get our response
             $response = file_get_contents($url, false, $this->stream);
-
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             // set our error message/code and return false
             $this->errorMessage = $e->getMessage();
             $this->errorCode    = $e->getCode();
             return false;
-
         }
 
         // set response headers
         $this->responseHeaders = $http_response_header;
 
         return $response;
-
     }
 
     /**
@@ -83,7 +79,6 @@ class ParseStream
     public function getResponseHeaders()
     {
         return $this->responseHeaders;
-
     }
 
     /**
@@ -94,7 +89,6 @@ class ParseStream
     public function getErrorMessage()
     {
         return $this->errorMessage;
-
     }
 
     /**
@@ -105,7 +99,5 @@ class ParseStream
     public function getErrorCode()
     {
         return $this->errorCode;
-
     }
-
 }

--- a/src/Parse/HttpClients/ParseStreamHttpClient.php
+++ b/src/Parse/HttpClients/ParseStreamHttpClient.php
@@ -7,7 +7,6 @@
 
 namespace Parse\HttpClients;
 
-
 use Parse\ParseException;
 
 class ParseStreamHttpClient implements ParseHttpable
@@ -74,9 +73,8 @@ class ParseStreamHttpClient implements ParseHttpable
 
     public function __construct()
     {
-        if(!isset($this->parseStream)) {
+        if (!isset($this->parseStream)) {
             $this->parseStream = new ParseStream();
-
         }
     }
 
@@ -91,7 +89,6 @@ class ParseStreamHttpClient implements ParseHttpable
     public function addRequestHeader($key, $value)
     {
         $this->headers[$key]    = $value;
-
     }
 
     /**
@@ -102,7 +99,6 @@ class ParseStreamHttpClient implements ParseHttpable
     public function getResponseHeaders()
     {
         return $this->responseHeaders;
-
     }
 
     /**
@@ -113,7 +109,6 @@ class ParseStreamHttpClient implements ParseHttpable
     public function getResponseStatusCode()
     {
         return $this->responseCode;
-
     }
 
     /**
@@ -124,7 +119,6 @@ class ParseStreamHttpClient implements ParseHttpable
     public function getResponseContentType()
     {
         return $this->responseContentType;
-
     }
 
     /**
@@ -136,20 +130,17 @@ class ParseStreamHttpClient implements ParseHttpable
     {
         // coalesce our header key/value pairs
         $headers = [];
-        foreach($this->headers as $key => $value) {
-            if($key == 'Expect' && $value == '') {
+        foreach ($this->headers as $key => $value) {
+            if ($key == 'Expect' && $value == '') {
                 // drop this pair
                 continue;
-
             }
 
             // add this header key/value pair
             $headers[] = $key.': '.$value;
-
         }
 
         return implode("\r\n", $headers);
-
     }
 
     public function setup()
@@ -161,22 +152,19 @@ class ParseStreamHttpClient implements ParseHttpable
             'allow_self_signed' => true, // All root certificates are self-signed
             'follow_location'   => 1
         );
-
     }
 
     public function send($url, $method = 'GET', $data = array())
     {
 
         // verify this url
-        if(preg_match('/\s/', trim($url))) {
+        if (preg_match('/\s/', trim($url))) {
             throw new ParseException('Url may not contain spaces for stream client: '.$url);
-
         }
 
-        if(isset($this->caFile)) {
+        if (isset($this->caFile)) {
             // set CA file as well
             $this->options['ssl']['cafile'] = $this->caFile;
-
         }
 
         // add additional options for this request
@@ -185,28 +173,23 @@ class ParseStreamHttpClient implements ParseHttpable
             'ignore_errors' => true
         );
 
-        if(isset($this->timeout)) {
+        if (isset($this->timeout)) {
             $this->options['http']['timeout']   = $this->timeout;
-
         }
 
-        if(isset($data) && $data != "{}") {
+        if (isset($data) && $data != "{}") {
             if ($method == "GET") {
                 // handle GET
                 $query = http_build_query($data, null, '&');
                 $this->options['http']['content'] = $query;
                 $this->addRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-
-            } else if ($method == "POST") {
+            } elseif ($method == "POST") {
                 // handle POST
                 $this->options['http']['content'] = $data;
-
-            } else if ($method == "PUT") {
+            } elseif ($method == "PUT") {
                 // handle PUT
                 $this->options['http']['content'] = $data;
-
             }
-
         }
 
         // set headers
@@ -225,21 +208,17 @@ class ParseStreamHttpClient implements ParseHttpable
             // set an error and code
             $this->streamErrorMessage   = $this->parseStream->getErrorMessage();
             $this->streamErrorCode      = $this->parseStream->getErrorCode();
-
         } else {
-
             // set our response headers
             $this->responseHeaders = self::formatHeaders($rawHeaders);
 
             // get and set content type, if present
-            if(isset($this->responseHeaders['Content-Type'])) {
+            if (isset($this->responseHeaders['Content-Type'])) {
                 $this->responseContentType = $this->responseHeaders['Content-Type'];
-
             }
 
             // set our http status code
             $this->responseCode = self::getStatusCodeFromHeader($this->responseHeaders['http_code']);
-
         }
 
         // clear options
@@ -249,7 +228,6 @@ class ParseStreamHttpClient implements ParseHttpable
         $this->headers = array();
 
         return $response;
-
     }
 
     /**
@@ -267,17 +245,14 @@ class ParseStreamHttpClient implements ParseHttpable
             if (strpos($line, ':') === false) {
                 // set our http status code
                 $headers['http_code'] = $line;
-
             } else {
                 // set this header entry
                 list ($key, $value) = explode(': ', $line);
                 $headers[$key]      = $value;
-
             }
         }
 
         return $headers;
-
     }
     /**
      * Extracts the Http status code from the given header
@@ -290,7 +265,6 @@ class ParseStreamHttpClient implements ParseHttpable
     {
         preg_match('{HTTP/\d\.\d\s+(\d+)\s+.*}', $header, $match);
         return (int) $match[1];
-
     }
 
     /**
@@ -301,7 +275,6 @@ class ParseStreamHttpClient implements ParseHttpable
     public function getErrorCode()
     {
         return $this->streamErrorCode;
-
     }
 
     /**
@@ -312,7 +285,6 @@ class ParseStreamHttpClient implements ParseHttpable
     public function getErrorMessage()
     {
         return $this->streamErrorMessage;
-
     }
 
     public function setConnectionTimeout($timeout)
@@ -328,7 +300,6 @@ class ParseStreamHttpClient implements ParseHttpable
     public function setCAFile($caFile)
     {
         $this->caFile = $caFile;
-
     }
 
     /**
@@ -339,8 +310,5 @@ class ParseStreamHttpClient implements ParseHttpable
     public function setTimeout($timeout)
     {
         $this->timeout = $timeout;
-
     }
-
-
 }

--- a/src/Parse/Internal/ParseRelationOperation.php
+++ b/src/Parse/Internal/ParseRelationOperation.php
@@ -63,9 +63,8 @@ class ParseRelationOperation implements FieldOperation
      */
     private function checkAndAssignClassName($objects)
     {
-        if(!is_array($objects)) {
+        if (!is_array($objects)) {
             $objects = [$objects];
-
         }
 
         foreach ($objects as $object) {

--- a/src/Parse/Internal/RemoveOperation.php
+++ b/src/Parse/Internal/RemoveOperation.php
@@ -106,9 +106,8 @@ class RemoveOperation implements FieldOperation
             return [];
         }
 
-        if(!is_array($oldValue)) {
+        if (!is_array($oldValue)) {
             $oldValue = [$oldValue];
-
         }
 
         $newValue = [];

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -124,9 +124,13 @@ final class ParseClient
      *
      * @throws Exception
      */
-    //@codingStandardsIgnoreLine
-    public static function initialize($app_id, $rest_key, $master_key, $enableCurlExceptions = true, $account_key = null)
-    {
+    public static function initialize(
+        $app_id,
+        $rest_key,
+        $master_key,
+        $enableCurlExceptions = true,
+        $account_key = null
+    ) {
         if (!ParseObject::hasRegisteredSubclass('_User')) {
             ParseUser::registerSubclass();
         }

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -124,6 +124,7 @@ final class ParseClient
      *
      * @throws Exception
      */
+    //@codingStandardsIgnoreLine
     public static function initialize($app_id, $rest_key, $master_key, $enableCurlExceptions = true, $account_key = null)
     {
         if (!ParseObject::hasRegisteredSubclass('_User')) {
@@ -138,7 +139,7 @@ final class ParseClient
             ParseInstallation::registerSubclass();
         }
 
-        if(!ParseObject::hasRegisteredSubclass('_PushStatus')) {
+        if (!ParseObject::hasRegisteredSubclass('_PushStatus')) {
             ParsePushStatus::registerSubclass();
         }
 
@@ -165,19 +166,20 @@ final class ParseClient
      * @throws \Exception
      *
      */
-    public static function setServerURL($serverURL, $mountPath) {
+    public static function setServerURL($serverURL, $mountPath)
+    {
         if (!$serverURL) {
             throw new Exception('Invalid Server URL.');
         }
-        if( !$mountPath) {
+        if (!$mountPath) {
             throw new Exception('Invalid Mount Path.');
         }
 
-        self::$serverURL = rtrim($serverURL,'/');
-        self::$mountPath = trim($mountPath,'/') . '/';
+        self::$serverURL = rtrim($serverURL, '/');
+        self::$mountPath = trim($mountPath, '/') . '/';
 
         // check if mount path is root
-        if(self::$mountPath == "/") {
+        if (self::$mountPath == "/") {
             // root path should have no mount path
             self::$mountPath = "";
         }
@@ -191,7 +193,6 @@ final class ParseClient
     public static function setHttpClient(ParseHttpable $httpClient)
     {
         self::$httpClient = $httpClient;
-
     }
 
     /**
@@ -204,13 +205,10 @@ final class ParseClient
         if (static::$httpClient) {
             // use existing client
             return static::$httpClient;
-
         } else {
             // default to cURL/stream
             return function_exists('curl_init') ? new ParseCurlHttpClient() : new ParseStreamHttpClient();
-
         }
-
     }
 
     /**
@@ -219,7 +217,6 @@ final class ParseClient
     public static function clearHttpClient()
     {
         self::$httpClient = null;
-
     }
 
     /**
@@ -230,7 +227,6 @@ final class ParseClient
     public static function setCAFile($caFile)
     {
         self::$caFile = $caFile;
-
     }
 
     /**
@@ -399,10 +395,9 @@ final class ParseClient
         // setup
         $httpClient->setup();
 
-        if(isset(self::$caFile)) {
+        if (isset(self::$caFile)) {
             // set CA file
             $httpClient->setCAFile(self::$caFile);
-
         }
 
         if ($appRequest) {
@@ -410,7 +405,6 @@ final class ParseClient
             self::assertAppInitialized();
 
             $httpClient->addRequestHeader('X-Parse-Account-Key', self::$accountKey);
-
         } else {
             self::assertParseInitialized();
 
@@ -422,25 +416,20 @@ final class ParseClient
             if ($sessionToken) {
                 // add our current session token
                 $httpClient->addRequestHeader('X-Parse-Session-Token', $sessionToken);
-
             }
 
             if ($useMasterKey) {
                 // pass master key
                 $httpClient->addRequestHeader('X-Parse-Master-Key', self::$masterKey);
-
-            } else if(isset(self::$restKey)) {
+            } elseif (isset(self::$restKey)) {
                 // pass REST key
                 $httpClient->addRequestHeader('X-Parse-REST-API-Key', self::$restKey);
-
             }
 
             if (self::$forceRevocableSession) {
                 // indicate we are using revocable sessions
                 $httpClient->addRequestHeader('X-Parse-Revocable-Session', '1');
-
             }
-
         }
 
         /*
@@ -453,22 +442,19 @@ final class ParseClient
         // create request url
         $url = self::$serverURL . '/' . self::$mountPath.ltrim($relativeUrl, '/');
 
-        if($method === 'POST' || $method === 'PUT') {
+        if ($method === 'POST' || $method === 'PUT') {
             // add content type to the request
             $httpClient->addRequestHeader('Content-type', $contentType);
-
         }
 
         if (!is_null(self::$connectionTimeout)) {
             // set connection timeout
             $httpClient->setConnectionTimeout(self::$connectionTimeout);
-
         }
 
         if (!is_null(self::$timeout)) {
             // set request/response timeout
             $httpClient->setTimeout(self::$timeout);
-
         }
 
         // send our request
@@ -479,28 +465,24 @@ final class ParseClient
 
         if (strpos($contentType, 'text/html') !== false) {
             throw new ParseException('Bad Request', -1);
-
         }
 
-        if($httpClient->getErrorCode()) {
-            if(self::$enableCurlExceptions) {
+        if ($httpClient->getErrorCode()) {
+            if (self::$enableCurlExceptions) {
                 throw new ParseException($httpClient->getErrorMessage(), $httpClient->getErrorCode());
-
             } else {
                 return false;
-
             }
         }
 
         $decoded = json_decode($response, true);
 
-        if(!isset($decoded) && $response !== '') {
+        if (!isset($decoded) && $response !== '') {
             throw new ParseException(
                 'Bad Request. Could not decode Response: '.
                 '('.json_last_error().') '.self::getLastJSONErrorMsg(),
                 -1
             );
-
         }
 
         if (isset($decoded['error'])) {
@@ -515,11 +497,9 @@ final class ParseClient
 
         if ($returnHeaders) {
             $decoded['_headers'] = $httpClient->getResponseHeaders();
-
         }
 
         return $decoded;
-
     }
 
     /**
@@ -543,12 +523,10 @@ final class ParseClient
 
             $error = json_last_error();
             return isset($error_strings[$error]) ? $error_strings[$error] : 'Unknown error';
-
         }
 
         // use existing function
         return json_last_error_msg();
-
     }
 
     /**

--- a/src/Parse/ParseConfig.php
+++ b/src/Parse/ParseConfig.php
@@ -42,6 +42,5 @@ class ParseConfig
     public function getConfig()
     {
         return $this->currentConfig;
-
     }
 }

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -99,7 +99,6 @@ class ParseFile implements Encodable
             null,
             $useMasterKey
         );
-
     }
 
     /**
@@ -109,16 +108,14 @@ class ParseFile implements Encodable
      */
     public function getMimeType()
     {
-        if(isset($this->mimeType)) {
+        if (isset($this->mimeType)) {
             // return the mime type
             return $this->mimeType;
-
         } else {
             // return an inferred mime type instead
             $fileParts = explode('.', $this->getName());
             $extension = array_pop($fileParts);
             return $this->getMimeTypeForExtension($extension);
-
         }
     }
 
@@ -231,7 +228,6 @@ class ParseFile implements Encodable
             false,
             $mimeType
         );
-
     }
 
     private function download()

--- a/src/Parse/ParseGeoPoint.php
+++ b/src/Parse/ParseGeoPoint.php
@@ -57,8 +57,8 @@ class ParseGeoPoint implements Encodable
     public function setLatitude($lat)
     {
         if (is_numeric($lat) && !is_float($lat)) {
-            $lat = (float)$lat;    
-        }      
+            $lat = (float)$lat;
+        }
         if ($lat > 90.0 || $lat < -90.0) {
             throw new ParseException('Latitude must be within range [-90.0, 90.0]');
         }
@@ -85,8 +85,8 @@ class ParseGeoPoint implements Encodable
     public function setLongitude($lon)
     {
         if (is_numeric($lon) && !is_float($lon)) {
-            $lon = (float)$lon;    
-        }      
+            $lon = (float)$lon;
+        }
         if ($lon > 180.0 || $lon < -180.0) {
             throw new ParseException(
                 'Longitude must be within range [-180.0, 180.0]'

--- a/src/Parse/ParseInstallation.php
+++ b/src/Parse/ParseInstallation.php
@@ -19,7 +19,6 @@ class ParseInstallation extends ParseObject
     public function getInstallationId()
     {
         return $this->get('installationId');
-
     }
 
     /**
@@ -30,7 +29,6 @@ class ParseInstallation extends ParseObject
     public function getDeviceToken()
     {
         return $this->get('deviceToken');
-
     }
 
     /**
@@ -41,7 +39,6 @@ class ParseInstallation extends ParseObject
     public function getChannels()
     {
         return $this->get('channels');
-
     }
 
     /**
@@ -52,7 +49,6 @@ class ParseInstallation extends ParseObject
     public function getDeviceType()
     {
         return $this->get('deviceType');
-
     }
 
     /**
@@ -63,7 +59,6 @@ class ParseInstallation extends ParseObject
     public function getPushType()
     {
         return $this->get('pushType');
-
     }
 
     /**
@@ -74,7 +69,6 @@ class ParseInstallation extends ParseObject
     public function getGCMSenderId()
     {
         return $this->get('GCMSenderId');
-
     }
 
     /**
@@ -85,7 +79,6 @@ class ParseInstallation extends ParseObject
     public function getTimeZone()
     {
         return $this->get('timeZone');
-
     }
 
     /**
@@ -96,7 +89,6 @@ class ParseInstallation extends ParseObject
     public function getLocaleIdentifier()
     {
         return $this->get('localeIdentifier');
-
     }
 
     /**
@@ -107,7 +99,6 @@ class ParseInstallation extends ParseObject
     public function getBadge()
     {
         return $this->get('badge');
-
     }
 
     /**
@@ -118,7 +109,6 @@ class ParseInstallation extends ParseObject
     public function getAppVersion()
     {
         return $this->get('appVersion');
-
     }
 
     /**
@@ -129,7 +119,6 @@ class ParseInstallation extends ParseObject
     public function getAppName()
     {
         return $this->get('appName');
-
     }
 
     /**
@@ -140,7 +129,6 @@ class ParseInstallation extends ParseObject
     public function getAppIdentifier()
     {
         return $this->get('appIdentifier');
-
     }
 
     /**
@@ -151,7 +139,5 @@ class ParseInstallation extends ParseObject
     public function getParseVersion()
     {
         return $this->get('parseVersion');
-
     }
-
 }

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -806,16 +806,16 @@ class ParseObject implements Encodable
      */
     private static function destroyBatch(array $objects, $useMasterKey = false)
     {
-        //@codingStandardsIgnoreStart
         $data = [];
         $errors = [];
         foreach ($objects as $object) {
             $data[] = [
                 'method' => 'DELETE',
-                'path'   => '/'.ParseClient::getMountPath().'classes/'.$object->getClassName().'/'.$object->getObjectId(),
+                'path'   => '/'.ParseClient::getMountPath().
+                'classes/'.$object->getClassName().
+                '/'.$object->getObjectId(),
             ];
         }
-        //@codingStandardsIgnoreEnd
         $sessionToken = null;
         if (ParseUser::getCurrentUser()) {
             $sessionToken = ParseUser::getCurrentUser()->getSessionToken();

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -230,7 +230,6 @@ class ParseObject implements Encodable
     public function has($key)
     {
         return isset($this->estimatedData[$key]);
-
     }
 
     /**
@@ -807,6 +806,7 @@ class ParseObject implements Encodable
      */
     private static function destroyBatch(array $objects, $useMasterKey = false)
     {
+        //@codingStandardsIgnoreStart
         $data = [];
         $errors = [];
         foreach ($objects as $object) {
@@ -815,6 +815,7 @@ class ParseObject implements Encodable
                 'path'   => '/'.ParseClient::getMountPath().'classes/'.$object->getClassName().'/'.$object->getObjectId(),
             ];
         }
+        //@codingStandardsIgnoreEnd
         $sessionToken = null;
         if (ParseUser::getCurrentUser()) {
             $sessionToken = ParseUser::getCurrentUser()->getSessionToken();
@@ -940,7 +941,9 @@ class ParseObject implements Encodable
      *
      * @return void
      */
-    public function beforeSave(){}
+    public function beforeSave()
+    {
+    }
 
     /**
      * Save Object to Parse.
@@ -1112,7 +1115,6 @@ class ParseObject implements Encodable
                         $unsavedFiles[] = $obj;
                     }
                 }
-
             }
         );
     }

--- a/src/Parse/ParsePush.php
+++ b/src/Parse/ParsePush.php
@@ -91,7 +91,6 @@ class ParsePush
             isset($response['_headers']) &&
             isset($response['_headers']['X-Parse-Push-Status-Id'])
         );
-
     }
 
     /**
@@ -102,18 +101,16 @@ class ParsePush
      */
     public static function getStatus($response)
     {
-        if(!isset($response['_headers'])) {
+        if (!isset($response['_headers'])) {
             // missing headers
             return null;
-
         }
 
         $headers = $response['_headers'];
 
-        if(!isset($headers['X-Parse-Push-Status-Id'])) {
+        if (!isset($headers['X-Parse-Push-Status-Id'])) {
             // missing push status id
             return null;
-
         }
 
         // get our push status id
@@ -121,6 +118,5 @@ class ParsePush
 
         // return our push status if it exists
         return ParsePushStatus::getFromId($pushStatusId);
-
     }
 }

--- a/src/Parse/ParsePushStatus.php
+++ b/src/Parse/ParsePushStatus.php
@@ -34,13 +34,10 @@ class ParsePushStatus extends ParseObject
             // return the associated PushStatus object
             $query = new ParseQuery(self::$parseClassName);
             return $query->get($id, true);
-
         } catch (ParseException $pe) {
             // no push found
             return null;
-
         }
-
     }
 
     /**
@@ -51,7 +48,6 @@ class ParsePushStatus extends ParseObject
     public function getPushTime()
     {
         return new \DateTime($this->get("pushTime"));
-
     }
 
     /**
@@ -73,7 +69,6 @@ class ParsePushStatus extends ParseObject
         $query->_setConditions($queryConditions);
 
         return $query;
-
     }
 
     /**
@@ -84,7 +79,6 @@ class ParsePushStatus extends ParseObject
     public function getPushPayload()
     {
         return json_decode($this->get("payload"), true);
-
     }
 
     /**
@@ -95,7 +89,6 @@ class ParsePushStatus extends ParseObject
     public function getPushSource()
     {
         return $this->get("source");
-
     }
 
     /**
@@ -106,7 +99,6 @@ class ParsePushStatus extends ParseObject
     public function getPushStatus()
     {
         return $this->get("status");
-
     }
 
     /**
@@ -117,7 +109,6 @@ class ParsePushStatus extends ParseObject
     public function isScheduled()
     {
         return $this->getPushStatus() === self::STATUS_SCHEDULED;
-
     }
 
     /**
@@ -128,7 +119,6 @@ class ParsePushStatus extends ParseObject
     public function isPending()
     {
         return $this->getPushStatus() === self::STATUS_PENDING;
-
     }
 
     /**
@@ -139,7 +129,6 @@ class ParsePushStatus extends ParseObject
     public function isRunning()
     {
         return $this->getPushStatus() === self::STATUS_RUNNING;
-
     }
 
     /**
@@ -150,7 +139,6 @@ class ParsePushStatus extends ParseObject
     public function hasSucceeded()
     {
         return $this->getPushStatus() === self::STATUS_SUCCEEDED;
-
     }
 
     /**
@@ -161,7 +149,6 @@ class ParsePushStatus extends ParseObject
     public function hasFailed()
     {
         return $this->getPushStatus() === self::STATUS_FAILED;
-
     }
 
     /**
@@ -172,7 +159,6 @@ class ParsePushStatus extends ParseObject
     public function getPushesSent()
     {
         return $this->get("numSent");
-
     }
 
     /**
@@ -183,7 +169,6 @@ class ParsePushStatus extends ParseObject
     public function getPushHash()
     {
         return $this->get("pushHash");
-
     }
 
     /**
@@ -194,6 +179,5 @@ class ParsePushStatus extends ParseObject
     public function getPushesFailed()
     {
         return $this->get("numFailed");
-
     }
 }

--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -142,20 +142,16 @@ class ParseQuery
      */
     public function _setConditions($conditions)
     {
-        if(!is_array($conditions)) {
+        if (!is_array($conditions)) {
             throw new ParseException("Conditions must be in an array");
-
         }
 
         // iterate over and add each condition
-        foreach($conditions as $key => $entry) {
-            foreach($entry as $condition => $value) {
+        foreach ($conditions as $key => $entry) {
+            foreach ($entry as $condition => $value) {
                 $this->addCondition($key, $condition, $value);
-
             }
-
         }
-
     }
 
     /**

--- a/src/Parse/ParseRole.php
+++ b/src/Parse/ParseRole.php
@@ -104,16 +104,14 @@ class ParseRole extends ParseObject
                 'Roles must have a name.'
             );
         }
-        if($this->getObjectId() === null) {
+        if ($this->getObjectId() === null) {
             // Not yet saved, verify this name is not taken
             // ParseServer does not validate duplicate role names as of parse-server v2.3.2
             $query = new ParseQuery('_Role');
             $query->equalTo('name', $this->getName());
-            if($query->count(true) > 0) {
+            if ($query->count(true) > 0) {
                 throw new ParseException("Cannot add duplicate role name of '{$this->getName()}'");
-
             }
-
         }
 
         return parent::save($useMasterKey);

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -192,7 +192,8 @@ class ParseUser extends ParseObject
         $screen_name,
         $consumer_key,
         $consumer_secret = null,
-        $auth_token, //@codingStandardsIgnoreLine
+        //@codingStandardsIgnoreLine
+        $auth_token,
         $auth_token_secret
     ) {
 
@@ -247,11 +248,16 @@ class ParseUser extends ParseObject
          * @link https://en.wikipedia.org/wiki/Universally_unique_identifier
          */
         $uuid_parts = str_split(md5(mt_rand()), 4);
-        //@codingStandardsIgnoreStart
         $authData = [
-            'id' => $uuid_parts[0].$uuid_parts[1].'-'.$uuid_parts[2].'-'.$uuid_parts[3].'-'.$uuid_parts[4].'-'.$uuid_parts[5].$uuid_parts[6].$uuid_parts[7],
+            'id' => $uuid_parts[0].
+                    $uuid_parts[1].'-'.
+                    $uuid_parts[2].'-'.
+                    $uuid_parts[3].'-'.
+                    $uuid_parts[4].'-'.
+                    $uuid_parts[5].
+                    $uuid_parts[6].
+                    $uuid_parts[7],
         ];
-        //@codingStandardsIgnoreEnd
         return self::logInWith('anonymous', $authData);
     }
 
@@ -342,7 +348,8 @@ class ParseUser extends ParseObject
         $screen_name,
         $consumer_key,
         $consumer_secret = null,
-        $auth_token, //@codingStandardsIgnoreLine
+        //@codingStandardsIgnoreLine
+        $auth_token,
         $auth_token_secret,
         $useMasterKey = false
     ) {

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -192,9 +192,10 @@ class ParseUser extends ParseObject
         $screen_name,
         $consumer_key,
         $consumer_secret = null,
-        $auth_token,
-        $auth_token_secret)
-    {
+        $auth_token, //@codingStandardsIgnoreLine
+        $auth_token_secret
+    ) {
+
         if (!$id) {
             throw new ParseException('Cannot log in Twitter user without an id.');
         }
@@ -246,10 +247,11 @@ class ParseUser extends ParseObject
          * @link https://en.wikipedia.org/wiki/Universally_unique_identifier
          */
         $uuid_parts = str_split(md5(mt_rand()), 4);
+        //@codingStandardsIgnoreStart
         $authData = [
             'id' => $uuid_parts[0].$uuid_parts[1].'-'.$uuid_parts[2].'-'.$uuid_parts[3].'-'.$uuid_parts[4].'-'.$uuid_parts[5].$uuid_parts[6].$uuid_parts[7],
         ];
-
+        //@codingStandardsIgnoreEnd
         return self::logInWith('anonymous', $authData);
     }
 
@@ -291,11 +293,13 @@ class ParseUser extends ParseObject
         $id,
         $access_token,
         $expiration_date = null,
-        $useMasterKey = false)
-    {
+        $useMasterKey = false
+    ) {
+
         if (!$this->getObjectId()) {
             throw new ParseException(
-                'Cannot link an unsaved user, use ParseUser::logInWithFacebook');
+                'Cannot link an unsaved user, use ParseUser::logInWithFacebook'
+            );
         }
         if (!$id) {
             throw new ParseException('Cannot link Facebook user without an id.');
@@ -338,10 +342,11 @@ class ParseUser extends ParseObject
         $screen_name,
         $consumer_key,
         $consumer_secret = null,
-        $auth_token,
+        $auth_token, //@codingStandardsIgnoreLine
         $auth_token_secret,
-        $useMasterKey = false)
-    {
+        $useMasterKey = false
+    ) {
+
         if (!$this->getObjectId()) {
             throw new ParseException('Cannot link an unsaved user, use ParseUser::logInWithTwitter');
         }

--- a/tests/Parse/AddOperationTest.php
+++ b/tests/Parse/AddOperationTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\Internal\AddOperation;
 use Parse\Internal\DeleteOperation;
 use Parse\Internal\SetOperation;
@@ -32,7 +31,6 @@ class AddOperationTest extends \PHPUnit_Framework_TestCase
         $addOp = new AddOperation($objects);
 
         $this->assertEquals($objects, $addOp->getValue());
-
     }
 
     /**
@@ -40,10 +38,11 @@ class AddOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadObjects()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'AddOperation requires an array.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'AddOperation requires an array.'
+        );
         new AddOperation('not an array');
-
     }
 
     /**
@@ -76,7 +75,6 @@ class AddOperationTest extends \PHPUnit_Framework_TestCase
             'key2'  => 'value2',
             'key1'  => 'value1'
         ], $merged->getValue(), 'Value was not as expected');
-
     }
 
     /**
@@ -84,12 +82,13 @@ class AddOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'Operation is invalid after previous operation.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'Operation is invalid after previous operation.'
+        );
         $addOp = new AddOperation([
             'key1'          => 'value1'
         ]);
         $addOp->_mergeWithPrevious(new \DateTime());
-
     }
 }

--- a/tests/Parse/AddUniqueOperationTest.php
+++ b/tests/Parse/AddUniqueOperationTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\Internal\AddUniqueOperation;
 use Parse\Internal\DeleteOperation;
 use Parse\Internal\IncrementOperation;
@@ -42,7 +41,6 @@ class AddUniqueOperationTest extends \PHPUnit_Framework_TestCase
         $addUnique = new AddUniqueOperation($objects);
 
         $this->assertEquals($objects, $addUnique->getValue());
-
     }
 
     /**
@@ -50,10 +48,11 @@ class AddUniqueOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadObjects()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'AddUniqueOperation requires an array.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'AddUniqueOperation requires an array.'
+        );
         $addUnique = new AddUniqueOperation('not-an-array');
-
     }
 
     /**
@@ -73,7 +72,6 @@ class AddUniqueOperationTest extends \PHPUnit_Framework_TestCase
             '__op'      => 'AddUnique',
             'objects'   => ParseClient::_encode($objects, true)
         ], $encoded);
-
     }
 
     /**
@@ -106,7 +104,6 @@ class AddUniqueOperationTest extends \PHPUnit_Framework_TestCase
             'key2'  => 'value2',
             'value1'
         ], $merged->getValue(), 'Value was not as expected');
-
     }
 
     /**
@@ -114,13 +111,14 @@ class AddUniqueOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'Operation is invalid after previous operation.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'Operation is invalid after previous operation.'
+        );
         $addOp = new AddUniqueOperation([
             'key1'          => 'value1'
         ]);
         $addOp->_mergeWithPrevious(new IncrementOperation());
-
     }
 
     /**
@@ -160,6 +158,5 @@ class AddUniqueOperationTest extends \PHPUnit_Framework_TestCase
         ]);
         $oldValue = $addOp->_apply($obj1, null, null);
         $this->assertEquals($obj1, $oldValue[0]);
-
     }
 }

--- a/tests/Parse/Helper.php
+++ b/tests/Parse/Helper.php
@@ -51,7 +51,6 @@ class Helper
         );
         self::setServerURL();
         self::setHttpClient();
-
     }
 
     public static function setHttpClient()
@@ -64,20 +63,18 @@ class Helper
         // ParseStreamHttpClient
         //
 
-        if(function_exists('curl_init')) {
+        if (function_exists('curl_init')) {
             // cURL client
             ParseClient::setHttpClient(new ParseCurlHttpClient());
-
         } else {
             // stream client
             ParseClient::setHttpClient(new ParseStreamHttpClient());
         }
-
     }
 
     public static function setServerURL()
     {
-        ParseClient::setServerURL('http://localhost:1337','parse');
+        ParseClient::setServerURL('http://localhost:1337', 'parse');
     }
 
     public static function tearDown()
@@ -104,6 +101,5 @@ class Helper
             false,
             self::$accountKey
         );
-
     }
 }

--- a/tests/Parse/IncrementOperationTest.php
+++ b/tests/Parse/IncrementOperationTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\Internal\AddOperation;
 use Parse\Internal\DeleteOperation;
 use Parse\Internal\IncrementOperation;
@@ -29,7 +28,6 @@ class IncrementOperationTest extends \PHPUnit_Framework_TestCase
     {
         $addOp = new IncrementOperation(32);
         $this->assertEquals(32, $addOp->getValue());
-
     }
 
     /**
@@ -54,7 +52,6 @@ class IncrementOperationTest extends \PHPUnit_Framework_TestCase
         $merged = $addOp->_mergeWithPrevious(new IncrementOperation(32));
         $this->assertTrue($merged instanceof IncrementOperation);
         $this->assertEquals(33, $merged->getValue(), 'Value was not as expected');
-
     }
 
     /**
@@ -62,10 +59,11 @@ class IncrementOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'Operation is invalid after previous operation.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'Operation is invalid after previous operation.'
+        );
         $addOp = new IncrementOperation();
         $addOp->_mergeWithPrevious(new AddOperation(['key'  => 'value']));
-
     }
 }

--- a/tests/Parse/ParseACLTest.php
+++ b/tests/Parse/ParseACLTest.php
@@ -28,10 +28,10 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
         Helper::tearDown();
     }
 
-    public function testIsSharedDefault() {
+    public function testIsSharedDefault()
+    {
         $acl = new ParseACL();
         $this->assertFalse($acl->_isShared());
-
     }
 
     /**
@@ -375,17 +375,18 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($objectAgain->getACL()->getPublicWriteAccess());
     }
 
-    public function testNullDefaultACL() {
+    public function testNullDefaultACL()
+    {
         // verify null acl returns itself
         ParseACL::setDefaultACL(null, true);
         $this->assertNull(ParseACL::_getDefaultACL());
-
     }
 
     /**
      * @group default-acls
      */
-    public function testDefaultACL() {
+    public function testDefaultACL()
+    {
         // setup default acl
         $defaultACL = new ParseACL();
         $defaultACL->setPublicReadAccess(false);
@@ -399,7 +400,7 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($acl->_isShared());
 
         // verify empty
-        $this->assertEquals(new \stdClass(),$acl->_encode());
+        $this->assertEquals(new \stdClass(), $acl->_encode());
 
         // login as new user
         $user = new ParseUser();
@@ -420,7 +421,6 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
 
         ParseUser::logOut();
         $user->destroy(true);
-
     }
 
     public function testIncludedObjectsGetACLWithDefaultACL()
@@ -453,50 +453,57 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
     /**
      * @group acl-invalid
      */
-    public function testCreatingACLWithInvalidId() {
-        $this->setExpectedException('\Exception',
-            'Tried to create an ACL with an invalid userId.');
+    public function testCreatingACLWithInvalidId()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'Tried to create an ACL with an invalid userId.'
+        );
 
         ParseACL::_createACLFromJSON([
             1234    => 'write'
         ]);
-
     }
 
     /**
      * @group acl-invalid
      */
-    public function testCreatingWithBadAccessType() {
-        $this->setExpectedException('\Exception',
-            'Tried to create an ACL with an invalid permission type.');
+    public function testCreatingWithBadAccessType()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'Tried to create an ACL with an invalid permission type.'
+        );
 
         ParseACL::_createACLFromJSON([
             'id'    => [
                 'not-valid' => true
             ]
         ]);
-
     }
 
     /**
      * @group acl-invalid
      */
-    public function testCreatingWithInvalidPermissionValue() {
-        $this->setExpectedException('\Exception',
-            'Tried to create an ACL with an invalid permission value.');
+    public function testCreatingWithInvalidPermissionValue()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'Tried to create an ACL with an invalid permission value.'
+        );
 
         ParseACL::_createACLFromJSON([
             'id'    => [
                 'write' => 'not-valid'
             ]
         ]);
-
     }
 
     /**
      * @group acl-user-notallowed
      */
-    public function testSettingPermissionForUserNotAllowed() {
+    public function testSettingPermissionForUserNotAllowed()
+    {
         // add 'userid'
         $acl = new ParseACL();
         $acl->setPublicReadAccess(false);
@@ -516,13 +523,13 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
                 'read' => true
             ]
         ], $permissions);
-
     }
 
     /**
      * @group removing-from-acl
      */
-    public function testRemovingFromAcl() {
+    public function testRemovingFromAcl()
+    {
         // add 'userid'
         $acl = new ParseACL();
         $acl->setPublicReadAccess(false);
@@ -551,49 +558,57 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
         // verify acl is now empty, should be an instance of stdClass
         $permissions = $acl->_encode();
         $this->assertEquals(new \stdClass(), $permissions, 'ACL not empty after removing last user.');
-
     }
 
-    public function testSettingUserReadAccessWithoutId() {
-        $this->setExpectedException('\Exception',
-            'cannot setReadAccess for a user with null id');
+    public function testSettingUserReadAccessWithoutId()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'cannot setReadAccess for a user with null id'
+        );
 
         $acl = new ParseACL();
         $acl->setUserReadAccess(new ParseUser(), true);
-
     }
 
-    public function testGettingUserReadAccessWithoutId() {
-        $this->setExpectedException('\Exception',
-            'cannot getReadAccess for a user with null id');
+    public function testGettingUserReadAccessWithoutId()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'cannot getReadAccess for a user with null id'
+        );
 
         $acl = new ParseACL();
         $acl->getUserReadAccess(new ParseUser());
-
     }
 
-    public function testSettingUserWriteAccessWithoutId() {
-        $this->setExpectedException('\Exception',
-            'cannot setWriteAccess for a user with null id');
+    public function testSettingUserWriteAccessWithoutId()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'cannot setWriteAccess for a user with null id'
+        );
 
         $acl = new ParseACL();
         $acl->setUserWriteAccess(new ParseUser(), true);
-
     }
 
-    public function testGettingUserWriteAccessWithoutId() {
-        $this->setExpectedException('\Exception',
-            'cannot getWriteAccess for a user with null id');
+    public function testGettingUserWriteAccessWithoutId()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'cannot getWriteAccess for a user with null id'
+        );
 
         $acl = new ParseACL();
         $acl->getUserWriteAccess(new ParseUser());
-
     }
 
     /**
      * @group test-role-access
      */
-    public function testRoleAccess() {
+    public function testRoleAccess()
+    {
         $acl = new ParseACL();
 
         // Create a role
@@ -624,19 +639,21 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($acl->getRoleWriteAccess($role));
 
         $role->destroy(true);
-
     }
 
-    public function testUnsavedRoleAdded() {
-        $this->setExpectedException('\Exception',
-            'Roles must be saved to the server before they can be used in an ACL.');
+    public function testUnsavedRoleAdded()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'Roles must be saved to the server before they can be used in an ACL.'
+        );
 
         $acl = new ParseACL();
         $acl->setRoleReadAccess(new ParseRole(), true);
-
     }
 
-    public function testRoleAccessWithName() {
+    public function testRoleAccessWithName()
+    {
         $acl = new ParseACL();
         // Read Access
         $this->assertFalse($acl->getRoleReadAccessWithName('role'));
@@ -659,6 +676,5 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
         // set back to false
         $acl->setRoleWriteAccessWithName('role', false);
         $this->assertFalse($acl->getRoleWriteAccessWithName('role'));
-
     }
 }

--- a/tests/Parse/ParseAnalyticsTest.php
+++ b/tests/Parse/ParseAnalyticsTest.php
@@ -78,21 +78,21 @@ class ParseAnalyticsTest extends \PHPUnit_Framework_TestCase
         $this->assertAnalyticsValidation('testDate', $params, $expected);
     }
 
-    public function testBadKeyDimension() {
+    public function testBadKeyDimension()
+    {
         $this->setExpectedException(
             '\Exception',
             'Dimensions expected string keys and values.'
         );
         ParseAnalytics::track('event', [1=>'good-value']);
-
     }
 
-    public function testBadValueDimension() {
+    public function testBadValueDimension()
+    {
         $this->setExpectedException(
             '\Exception',
             'Dimensions expected string keys and values.'
         );
         ParseAnalytics::track('event', ['good-key'=>1]);
-
     }
 }

--- a/tests/Parse/ParseAppTest.php
+++ b/tests/Parse/ParseAppTest.php
@@ -14,8 +14,10 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testFetchingApps()
     {
-        $this->setExpectedException('Parse\ParseException',
-            'unauthorized');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'unauthorized'
+        );
 
         self::_createApp(self::_getNewName());
         self::_createApp(self::_getNewName());
@@ -26,8 +28,10 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testFetchSingleApp()
     {
-        $this->setExpectedException('Parse\ParseException',
-            'unauthorized');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'unauthorized'
+        );
 
         $app_created = self::_createApp(self::_getNewName());
 
@@ -46,8 +50,10 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testCreateApp()
     {
-        $this->setExpectedException('Parse\ParseException',
-            'unauthorized');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'unauthorized'
+        );
 
         $app_name = self::_getNewName();
 
@@ -64,8 +70,10 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testNameAlreadyInAccount()
     {
-        $this->setExpectedException('Parse\ParseException',
-            'unauthorized');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'unauthorized'
+        );
 
         $app_name = self::_getNewName();
 
@@ -81,8 +89,10 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testUpdateApp()
     {
-        $this->setExpectedException('Parse\ParseException',
-            'unauthorized');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'unauthorized'
+        );
 
         $app_name = self::_getNewName();
         $updated_name = self::_getNewName();

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\HttpClients\ParseCurlHttpClient;
 use Parse\HttpClients\ParseStreamHttpClient;
 use Parse\ParseClient;
@@ -31,8 +30,6 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
     {
         Helper::setServerURL();
         Helper::setHttpClient();
-
-
     }
 
     public function tearDown()
@@ -41,13 +38,13 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
 
         // unset CA file
         ParseClient::setCAFile(null);
-
     }
 
     /**
      * @group client-not-initialized
      */
-    public function testParseNotInitialized() {
+    public function testParseNotInitialized()
+    {
         $this->setExpectedException(
             '\Exception',
             'You must call Parse::initialize() before making any requests.'
@@ -63,15 +60,15 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
             '',
             ''
         );
-
-
     }
 
     /**
      * @group client-not-initialized
      */
-    public function testAppNotNotInitialized() {
-        $this->setExpectedException('\Exception',
+    public function testAppNotNotInitialized()
+    {
+        $this->setExpectedException(
+            '\Exception',
             'You must call Parse::initialize(..., $accountKey) before making any app requests. '.
             'Your account key must not be null or empty.'
         );
@@ -90,13 +87,13 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
             false,
             true
         );
-
     }
 
     /**
      * @group client-init
      */
-    public function testInitialize() {
+    public function testInitialize()
+    {
 
         // unregister associated sub classes
         ParseUser::_unregisterSubclass();
@@ -122,13 +119,13 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
 
         // verify storage is now set
         $this->assertNotNull(ParseClient::getStorage());
-
     }
 
     /**
      * @group client-storage
      */
-    public function testStorage() {
+    public function testStorage()
+    {
 
         // unset storage
         ParseClient::_unsetStorage();
@@ -143,8 +140,10 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         );
 
         $storage = ParseClient::getStorage();
-        $this->assertTrue($storage instanceof ParseMemoryStorage,
-            'Not an instance of ParseMemoryStorage');
+        $this->assertTrue(
+            $storage instanceof ParseMemoryStorage,
+            'Not an instance of ParseMemoryStorage'
+        );
 
         /* TODO can't get session storage test to pass properly
         // unset storage
@@ -180,69 +179,78 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
     /**
      * @group client-test
      */
-    public function testSetServerURL() {
+    public function testSetServerURL()
+    {
         // add extra slashes to test removal
         ParseClient::setServerURL('https://example.com//', '//parse//');
 
         // verify APIUrl
         $this->assertEquals(
             'https://example.com/parse/',
-            ParseClient::getAPIUrl());
+            ParseClient::getAPIUrl()
+        );
 
         // verify mount path
         $this->assertEquals(
             'parse/',
             ParseClient::getMountPath()
         );
-
     }
 
     /**
      * @group client-test
      */
-    public function testRootMountPath() {
+    public function testRootMountPath()
+    {
         ParseClient::setServerURL('https://example.com', '/');
         $this->assertEquals(
             '',
             ParseClient::getMountPath(),
-            'Mount path was not reduced to an empty sequence for root');
-
+            'Mount path was not reduced to an empty sequence for root'
+        );
     }
 
     /**
      * @group client-test
      */
-    public function testBadServerURL() {
-        $this->setExpectedException('\Exception',
-            'Invalid Server URL.');
+    public function testBadServerURL()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'Invalid Server URL.'
+        );
         ParseClient::setServerURL(null, 'parse');
-
     }
 
     /**
      * @group client-test
      */
-    public function testBadMountPath() {
-        $this->setExpectedException('\Exception',
-            'Invalid Mount Path.');
+    public function testBadMountPath()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'Invalid Mount Path.'
+        );
         ParseClient::setServerURL('https://example.com', null);
-
     }
 
     /**
      * @group encoding-error
      */
-    public function testEncodingError() {
-        $this->setExpectedException('\Exception',
-            'Invalid type encountered.');
+    public function testEncodingError()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'Invalid type encountered.'
+        );
         ParseClient::_encode(new Helper(), false);
-
     }
 
     /**
      * @group client-decoding
      */
-    public function testDecodingStdClass() {
+    public function testDecodingStdClass()
+    {
         $obj = new \stdClass();
         $obj->property = 'value';
 
@@ -252,13 +260,13 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
 
         $emptyClass = new \stdClass();
         $this->assertEquals($emptyClass, ParseClient::_decode($emptyClass));
-
     }
 
     /**
      * @group timeouts
      */
-    public function testCurlTimeout() {
+    public function testCurlTimeout()
+    {
 
         ParseClient::setTimeout(3000);
 
@@ -273,13 +281,13 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
 
         // clear timeout
         ParseClient::setTimeout(null);
-
     }
 
     /**
      * @group timeouts
      */
-    public function testCurlConnectionTimeout() {
+    public function testCurlConnectionTimeout()
+    {
         ParseClient::setConnectionTimeout(3000);
 
         // perform a standard save
@@ -293,13 +301,13 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
 
         // clear timeout
         ParseClient::setConnectionTimeout(null);
-
     }
 
     /**
      * @group timeouts
      */
-    public function testStreamTimeout() {
+    public function testStreamTimeout()
+    {
 
         ParseClient::setHttpClient(new ParseStreamHttpClient());
 
@@ -316,13 +324,13 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
 
         // clear timeout
         ParseClient::setTimeout(null);
-
     }
 
     /**
      * @group timeouts
      */
-    public function testStreamConnectionTimeout() {
+    public function testStreamConnectionTimeout()
+    {
 
         ParseClient::setHttpClient(new ParseStreamHttpClient());
 
@@ -339,32 +347,33 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
 
         // clear timeout
         ParseClient::setConnectionTimeout(null);
-
     }
 
     /**
      * @group no-curl-exceptions
      */
-    public function testNoCurlExceptions() {
+    public function testNoCurlExceptions()
+    {
         Helper::setUpWithoutCURLExceptions();
 
         ParseClient::setServerURL('http://404.example.com', 'parse');
         $result = ParseClient::_request(
             'GET',
             'not-a-real-endpoint-to-reach',
-            null);
+            null
+        );
 
         $this->assertFalse($result);
 
         // put back
         Helper::setUp();
-
     }
 
     /**
      * @group curl-exceptions
      */
-    public function testCurlException() {
+    public function testCurlException()
+    {
 
         ParseClient::setHttpClient(new ParseCurlHttpClient());
 
@@ -374,14 +383,15 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         ParseClient::_request(
             'GET',
             'not-a-real-endpoint-to-reach',
-            null);
-
+            null
+        );
     }
 
     /**
      * @group stream-exceptions
      */
-    public function testStreamException() {
+    public function testStreamException()
+    {
 
         ParseClient::setHttpClient(new ParseStreamHttpClient());
 
@@ -391,8 +401,8 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         ParseClient::_request(
             'GET',
             'not-a-real-endpoint-to-reach',
-            null);
-
+            null
+        );
     }
 
     /**
@@ -406,8 +416,10 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadStreamRequest()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            "Bad Request");
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "Bad Request"
+        );
 
         ParseClient::setHttpClient(new ParseStreamHttpClient());
 
@@ -415,7 +427,8 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         ParseClient::_request(
             'GET',
             '',
-            null);
+            null
+        );
     }
 
     /**
@@ -423,8 +436,10 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testCurlBadRequest()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            "Bad Request");
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "Bad Request"
+        );
 
         ParseClient::setHttpClient(new ParseCurlHttpClient());
 
@@ -432,8 +447,8 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         ParseClient::_request(
             'GET',
             '',
-            null);
-
+            null
+        );
     }
 
     /**
@@ -447,16 +462,13 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         // get default client
         $default = ParseClient::getHttpClient();
 
-        if(function_exists('curl_init')) {
+        if (function_exists('curl_init')) {
             // should be a curl client
             $this->assertTrue($default instanceof ParseCurlHttpClient);
-
         } else {
             // should be a stream client
             $this->assertTrue($default instanceof ParseStreamHttpClient);
-
         }
-
     }
 
     /**
@@ -470,15 +482,17 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         // not a real ca file, just testing setting
         ParseClient::setCAFile("not-real-ca-file");
 
-        $this->setExpectedException('\Parse\ParseException',
-            "Bad Request");
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "Bad Request"
+        );
 
         ParseClient::setServerURL('http://example.com', '/');
         ParseClient::_request(
             'GET',
             '',
-            null);
-
+            null
+        );
     }
 
     /**
@@ -492,15 +506,17 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         // not a real ca file, just testing setting
         ParseClient::setCAFile("not-real-ca-file");
 
-        $this->setExpectedException('\Parse\ParseException',
-            "Bad Request");
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "Bad Request"
+        );
 
         ParseClient::setServerURL('http://example.com', '/');
         ParseClient::_request(
             'GET',
             '',
-            null);
-
+            null
+        );
     }
 
     /**
@@ -508,8 +524,10 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadApiResponse()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'Bad Request. Could not decode Response: (4) Syntax error');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'Bad Request. Could not decode Response: (4) Syntax error'
+        );
 
         $httpClient = ParseClient::getHttpClient();
 
@@ -533,7 +551,5 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
         // attempt to save, which should not fire our given code
         $obj = new ParseObject('TestingClass');
         $obj->save();
-
     }
-
 }

--- a/tests/Parse/ParseCloudTest.php
+++ b/tests/Parse/ParseCloudTest.php
@@ -17,27 +17,27 @@ class ParseCloudTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $user = ParseUser::getCurrentUser();
-        if(isset($user)) {
+        if (isset($user)) {
             ParseUser::logOut();
             $user->destroy(true);
-
         }
     }
 
     /**
      * @group cloud-code
      */
-    public function testFunctionCall() {
+    public function testFunctionCall()
+    {
         $response = ParseCloud::run('bar', [
             'key1'  => 'value2',
             'key2'  => 'value1'
         ]);
 
         $this->assertEquals('Foo', $response);
-
     }
 
-    public function testFunctionCallWithUser() {
+    public function testFunctionCallWithUser()
+    {
         $user = new ParseUser();
         $user->setUsername("someuser");
         $user->setPassword("somepassword");
@@ -52,15 +52,17 @@ class ParseCloudTest extends \PHPUnit_Framework_TestCase
 
         ParseUser::logOut();
         $user->destroy(true);
-
     }
 
     /**
      * @group cloud-code
      */
-    public function testFunctionCallException() {
-        $this->setExpectedException('\Parse\ParseException',
-            'bad stuff happened');
+    public function testFunctionCallException()
+    {
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'bad stuff happened'
+        );
 
         ParseCloud::run('bar', [
             'key1'  => 'value1',
@@ -80,7 +82,6 @@ class ParseCloudTest extends \PHPUnit_Framework_TestCase
         $params = ['key1' => $obj];
         $this->setExpectedException('\Exception', 'ParseObjects not allowed');
         ParseCloud::run('foo', $params);
-
     }
 
     /**
@@ -89,8 +90,10 @@ class ParseCloudTest extends \PHPUnit_Framework_TestCase
     public function testFunctionsWithGeoPointParamsDoNotThrow()
     {
         $params = ['key1' => new ParseGeoPoint(50, 50)];
-        $this->setExpectedException('Parse\ParseException',
-            'Invalid function: "unknown_function"');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Invalid function: "unknown_function"'
+        );
         ParseCloud::run('unknown_function', $params);
     }
 
@@ -100,8 +103,10 @@ class ParseCloudTest extends \PHPUnit_Framework_TestCase
     public function testUnknownFunctionFailure()
     {
         $params = ['key1' => 'value1'];
-        $this->setExpectedException('Parse\ParseException',
-            'Invalid function: "unknown_function"');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Invalid function: "unknown_function"'
+        );
         ParseCloud::run('unknown_function', $params);
     }
 }

--- a/tests/Parse/ParseConfigTest.php
+++ b/tests/Parse/ParseConfigTest.php
@@ -18,7 +18,6 @@ class ParseConfigTest extends \PHPUnit_Framework_TestCase
     {
         $config = new ParseConfig();
         $this->assertEquals([], $config->getConfig());
-
     }
 
     /**
@@ -35,13 +34,13 @@ class ParseConfigTest extends \PHPUnit_Framework_TestCase
 
         // check html value
         $this->assertEquals('<value>', $config->get('another'));
-
     }
 
     /**
      * @group parse-config
      */
-    public function testEscapeConfig() {
+    public function testEscapeConfig()
+    {
         $config = new ConfigMock();
 
         // check html encoded value
@@ -52,6 +51,5 @@ class ParseConfigTest extends \PHPUnit_Framework_TestCase
 
         // check normal value
         $this->assertEquals('bar', $config->escape('foo'));
-
     }
 }

--- a/tests/Parse/ParseCurlHttpClientTest.php
+++ b/tests/Parse/ParseCurlHttpClientTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\HttpClients\ParseCurlHttpClient;
 
 class ParseCurlHttpClientTest extends \PHPUnit_Framework_TestCase
@@ -20,6 +19,5 @@ class ParseCurlHttpClientTest extends \PHPUnit_Framework_TestCase
         $client->send("http://example.com");
 
         $this->assertEquals(200, $client->getResponseStatusCode());
-
     }
 }

--- a/tests/Parse/ParseCurlTest.php
+++ b/tests/Parse/ParseCurlTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\HttpClients\ParseCurl;
 use Parse\ParseException;
 
@@ -16,71 +15,78 @@ class ParseCurlTest extends \PHPUnit_Framework_TestCase
 {
     public function testBadExec()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'You must call ParseCurl::init first');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'You must call ParseCurl::init first'
+        );
 
         $parseCurl = new ParseCurl();
         $parseCurl->exec();
-
     }
 
     public function testBadSetOption()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'You must call ParseCurl::init first');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'You must call ParseCurl::init first'
+        );
 
         $parseCurl = new ParseCurl();
         $parseCurl->setOption(1, 1);
-
     }
 
     public function testBadSetOptionsArray()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'You must call ParseCurl::init first');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'You must call ParseCurl::init first'
+        );
 
         $parseCurl = new ParseCurl();
         $parseCurl->setOptionsArray([]);
-
     }
 
     public function testBadGetInfo()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'You must call ParseCurl::init first');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'You must call ParseCurl::init first'
+        );
 
         $parseCurl = new ParseCurl();
         $parseCurl->getInfo(1);
-
     }
 
     public function testBadGetError()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'You must call ParseCurl::init first');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'You must call ParseCurl::init first'
+        );
 
         $parseCurl = new ParseCurl();
         $parseCurl->getError();
-
     }
 
     public function testBadErrorCode()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'You must call ParseCurl::init first');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'You must call ParseCurl::init first'
+        );
 
         $parseCurl = new ParseCurl();
         $parseCurl->getErrorCode();
-
     }
 
     public function testBadClose()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'You must call ParseCurl::init first');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'You must call ParseCurl::init first'
+        );
 
         $parseCurl = new ParseCurl();
         $parseCurl->close();
-
     }
 }

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -67,11 +67,12 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseFileDownloadUnsaved()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'Cannot retrieve data for unsaved ParseFile.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'Cannot retrieve data for unsaved ParseFile.'
+        );
         $file = ParseFile::createFromData(null, 'file.txt');
         $file->getData();
-
     }
 
     /**
@@ -79,11 +80,12 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
      */
     public function testParsefileDeleteUnsaved()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'Cannot delete file that has not been saved.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'Cannot delete file that has not been saved.'
+        );
         $file = ParseFile::createFromData('a test file', 'file.txt');
         $file->delete();
-
     }
 
     /**
@@ -94,7 +96,6 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\Parse\ParseException', '', 6);
         $file = ParseFile::_createFromServer('file.txt', 'http://404.example.com');
         $file->getData();
-
     }
 
     /**

--- a/tests/Parse/ParseGeoBoxTest.php
+++ b/tests/Parse/ParseGeoBoxTest.php
@@ -63,7 +63,8 @@ class ParseGeoBoxTest extends \PHPUnit_Framework_TestCase
         /* , should fail because it crosses the dateline
         try {
             $results = $query->find();
-            $this->assertTrue(false, 'Query should fail because it crosses dateline, with results:'.json_encode($results[0]));
+            $this->assertTrue(false, 'Query should fail because it crosses
+            dateline with results:'.json_encode($results[0]));
         } catch (ParseException $e) {
         }
         */

--- a/tests/Parse/ParseHooksTest.php
+++ b/tests/Parse/ParseHooksTest.php
@@ -44,7 +44,6 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
         ], $function);
 
         self::$hooks->deleteFunction('baz');
-
     }
 
     public function testSingleFunctionNotFound()
@@ -82,8 +81,10 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
         try {
             self::$hooks->createFunction('baz', 'https://api.example.com/baz');
         } catch (ParseException $ex) {
-            $this->assertEquals('function name: baz already exits',
-                $ex->getMessage());
+            $this->assertEquals(
+                'function name: baz already exits',
+                $ex->getMessage()
+            );
         }
 
         self::$hooks->deleteFunction('baz');
@@ -122,9 +123,10 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
             self::$hooks->createTrigger('Game', 'beforeDelete', 'https://api.example.com/Game/beforeDelete');
             $this->fail();
         } catch (ParseException $ex) {
-            $this->assertEquals('class Game already has trigger beforeDelete',
-                $ex->getMessage());
-
+            $this->assertEquals(
+                'class Game already has trigger beforeDelete',
+                $ex->getMessage()
+            );
         }
 
         self::$hooks->deleteTrigger('Game', 'beforeDelete');
@@ -202,6 +204,5 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
         self::$hooks->deleteFunction('func1');
         self::$hooks->deleteFunction('func2');
         self::$hooks->deleteFunction('func3');
-
     }
 }

--- a/tests/Parse/ParseInstallationTest.php
+++ b/tests/Parse/ParseInstallationTest.php
@@ -2,7 +2,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\ParseException;
 use Parse\ParseInstallation;
 
@@ -23,8 +22,10 @@ class ParseInstallationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingIdentifyingField()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'at least one ID field (deviceToken, installationId) must be specified in this operation');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'at least one ID field (deviceToken, installationId) must be specified in this operation'
+        );
 
         (new ParseInstallation())->save();
     }
@@ -34,13 +35,14 @@ class ParseInstallationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingDeviceType()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'deviceType must be specified in this operation');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'deviceType must be specified in this operation'
+        );
 
         $installation = new ParseInstallation();
         $installation->set('deviceToken', '12345');
         $installation->save();
-
     }
 
     /**
@@ -48,12 +50,13 @@ class ParseInstallationTest extends \PHPUnit_Framework_TestCase
      */
     public function testClientsCannotFindWithoutMasterKey()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'Clients aren\'t allowed to perform the find operation on the installation collection.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'Clients aren\'t allowed to perform the find operation on the installation collection.'
+        );
 
         $query = ParseInstallation::query();
         $query->first();
-
     }
 
     /**
@@ -66,12 +69,13 @@ class ParseInstallationTest extends \PHPUnit_Framework_TestCase
         $installation->set('deviceType', 'android');
         $installation->save();
 
-        $this->setExpectedException('\Parse\ParseException',
-            "Clients aren't allowed to perform the delete operation on the installation collection.");
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "Clients aren't allowed to perform the delete operation on the installation collection."
+        );
 
         // try destroying, without using the master key
         $installation->destroy();
-
     }
 
     /**
@@ -136,7 +140,5 @@ class ParseInstallationTest extends \PHPUnit_Framework_TestCase
 
         // cleanup
         $installation->destroy(true);
-
     }
-
 }

--- a/tests/Parse/ParseMemoryStorageTest.php
+++ b/tests/Parse/ParseMemoryStorageTest.php
@@ -69,6 +69,5 @@ class ParseMemoryStorageTest extends \PHPUnit_Framework_TestCase
     {
         // does nothing
         self::$parseStorage->save();
-
     }
 }

--- a/tests/Parse/ParseObjectMock.php
+++ b/tests/Parse/ParseObjectMock.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\ParseObject;
 
 class ParseObjectMock extends ParseObject

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -108,7 +108,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $query = new ParseQuery('TestObject');
         $this->setExpectedException('Parse\ParseException', 'Object not found');
         $out = $query->get($obj->getObjectId());
-
     }
 
     public function testDeleteCurl()
@@ -122,7 +121,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $query = new ParseQuery('TestObject');
         $this->setExpectedException('Parse\ParseException', 'Object not found');
         $out = $query->get($obj->getObjectId());
-
     }
 
     public function testFind()
@@ -810,7 +808,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
         ParseUser::logOut();
         $user->destroy(true);
-
     }
 
     public function testEmptyArray()
@@ -958,7 +955,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $query = new ParseQuery('TestObject');
         $result = $query->find();
         $this->assertEquals(90, count($result));
-
     }
 
     public function testSaveAllCurl()
@@ -976,7 +972,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $query = new ParseQuery('TestObject');
         $result = $query->find();
         $this->assertEquals(90, count($result));
-
     }
 
     /**
@@ -1063,9 +1058,11 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testNoRegisteredSubclasses()
     {
-        $this->setExpectedException('\Exception',
+        $this->setExpectedException(
+            '\Exception',
             'You must initialize the ParseClient using ParseClient::initialize '.
-            'and your Parse API keys before you can begin working with Objects.');
+            'and your Parse API keys before you can begin working with Objects.'
+        );
         ParseUser::_unregisterSubclass();
         ParseRole::_unregisterSubclass();
         ParseInstallation::_unregisterSubclass();
@@ -1073,20 +1070,20 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         ParsePushStatus::_unregisterSubclass();
 
         new ParseObject('TestClass');
-
     }
 
     public function testMissingClassName()
     {
         Helper::setUp();
 
-        $this->setExpectedException('\Exception',
+        $this->setExpectedException(
+            '\Exception',
             'You must specify a Parse class name or register the appropriate '.
             'subclass when creating a new Object.    Use ParseObject::create to '.
-            'create a subclass object.');
+            'create a subclass object.'
+        );
 
         new ParseObjectMock();
-
     }
 
     public function testSettingProperties()
@@ -1095,16 +1092,16 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $obj->key = "value";
 
         $this->assertEquals('value', $obj->get('key'));
-
     }
 
     public function testSettingProtectedProperty()
     {
-        $this->setExpectedException('\Exception',
-            'Protected field could not be set.');
+        $this->setExpectedException(
+            '\Exception',
+            'Protected field could not be set.'
+        );
         $obj = new ParseObject('TestClass');
         $obj->updatedAt = "value";
-
     }
 
     public function testGettingProperties()
@@ -1112,7 +1109,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $obj = new ParseObject('TestClass');
         $obj->key = "value";
         $this->assertEquals('value', $obj->key);
-
     }
 
     public function testNullValues()
@@ -1131,7 +1127,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($obj->get('key2'));
 
         $obj->destroy();
-
     }
 
     public function testIsset()
@@ -1152,7 +1147,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         // null should return false
         $obj->set('key', null);
         $this->assertFalse(isset($obj->key), 'Failed on null');
-
     }
 
     public function testGetAllKeys()
@@ -1169,7 +1163,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
             'key2'  => 'value2',
             'key3'  => 'value3'
         ], $estimatedData);
-
     }
 
     /**
@@ -1232,16 +1225,16 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $obj->destroy();
         $obj2->destroy();
         $obj3->destroy();
-
     }
 
     public function testSetNullKey()
     {
-        $this->setExpectedException('\Exception',
-            'key may not be null.');
+        $this->setExpectedException(
+            '\Exception',
+            'key may not be null.'
+        );
         $obj = new ParseObject('TestClass');
         $obj->set(null, 'value');
-
     }
 
     public function testSetWithArrayValue()
@@ -1252,16 +1245,16 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         );
         $obj = new ParseObject('TestClass');
         $obj->set('key', ['is-an-array' => 'yes']);
-
     }
 
     public function testSetArrayNullKey()
     {
-        $this->setExpectedException('\Exception',
-            'key may not be null.');
+        $this->setExpectedException(
+            '\Exception',
+            'key may not be null.'
+        );
         $obj = new ParseObject('TestClass');
         $obj->setArray(null, ['is-an-array' => 'yes']);
-
     }
 
     public function testSetArrayWithNonArrayValue()
@@ -1272,16 +1265,16 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         );
         $obj = new ParseObject('TestClass');
         $obj->setArray('key', 'not-an-array');
-
     }
 
     public function testAsocSetArrayNullKey()
     {
-        $this->setExpectedException('\Exception',
-            'key may not be null.');
+        $this->setExpectedException(
+            '\Exception',
+            'key may not be null.'
+        );
         $obj = new ParseObject('TestClass');
         $obj->setAssociativeArray(null, ['is-an-array' => 'yes']);
-
     }
 
     public function testAsocSetArrayWithNonArrayValue()
@@ -1292,7 +1285,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         );
         $obj = new ParseObject('TestClass');
         $obj->setAssociativeArray('key', 'not-an-array');
-
     }
 
     public function testRemovingNullKey()
@@ -1303,7 +1295,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         );
         $obj = new ParseObject('TestClass');
         $obj->remove(null, 'value');
-
     }
 
     public function testRevert()
@@ -1316,19 +1307,19 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($obj->key1);
         $this->assertNull($obj->key2);
-
     }
 
     public function testEmptyFetchAll()
     {
         $this->assertEmpty(ParseObject::fetchAll([]));
-
     }
 
     public function testFetchAllMixedClasses()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'All objects should be of the same class.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'All objects should be of the same class.'
+        );
 
         $objs = [];
         $obj = new ParseObject('TestClass1');
@@ -1340,26 +1331,28 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $objs[] = $obj;
 
         ParseObject::fetchAll($objs);
-
     }
 
     public function testFetchAllUnsavedWithoutId()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'All objects must have an ID.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'All objects must have an ID.'
+        );
 
         $objs = [];
         $objs[] = new ParseObject('TestClass');
         $objs[] = new ParseObject('TestClass');
 
         ParseObject::fetchAll($objs);
-
     }
 
     public function testFetchAllUnsavedWithId()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'All objects must exist on the server.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'All objects must exist on the server.'
+        );
 
         $objs = [];
         $objs[] = new ParseObject('TestClass', 'objectid1');
@@ -1381,7 +1374,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('phpguy', $obj->montymxb);
 
         $obj->destroy();
-
     }
 
     public function testMergeFromServer()
@@ -1405,14 +1397,12 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('new value', $obj->get('key'));
 
         $obj->destroy();
-
     }
 
     public function testDestroyingUnsaved()
     {
         $obj = new ParseObject('TestClass');
         $obj->destroy();
-
     }
 
     public function testEncodeWithArray()
@@ -1422,15 +1412,15 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
         $encoded = json_decode($obj->_encode(), true);
         $this->assertEquals($encoded['arraykey'], ['value1','value2']);
-
     }
 
     public function testToPointerWithoutId()
     {
-        $this->setExpectedException('\Exception',
-            "Can't serialize an unsaved Parse.Object");
+        $this->setExpectedException(
+            '\Exception',
+            "Can't serialize an unsaved Parse.Object"
+        );
         (new ParseObject('TestClass'))->_toPointer();
-
     }
 
     public function testGettingSharedACL()
@@ -1445,15 +1435,15 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($copy !== $acl);
         $this->assertEquals($copy->_encode(), $acl->_encode());
-
     }
 
     public function testSubclassRegisterMissingParseClassName()
     {
-        $this->setExpectedException('\Exception',
-            'Cannot register a subclass that does not have a parseClassName');
+        $this->setExpectedException(
+            '\Exception',
+            'Cannot register a subclass that does not have a parseClassName'
+        );
         ParseObjectMock::registerSubclass();
-
     }
 
     public function testGetRegisteredSubclass()
@@ -1464,13 +1454,14 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $subclass = ParseObject::getRegisteredSubclass('Unknown');
         $this->assertTrue($subclass instanceof ParseObject);
         $this->assertEquals('Unknown', $subclass->getClassName());
-
     }
 
     public function testGettingQueryForUnregisteredSubclass()
     {
-        $this->setExpectedException('\Exception',
-            'Cannot create a query for an unregistered subclass.');
+        $this->setExpectedException(
+            '\Exception',
+            'Cannot create a query for an unregistered subclass.'
+        );
         ParseObjectMock::query();
     }
 
@@ -1492,6 +1483,5 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($encoded['key1'], $encodable1->_encode());
         $this->assertEquals($encoded['key2'][0], $encodable2->_encode());
-
     }
 }

--- a/tests/Parse/ParsePushTest.php
+++ b/tests/Parse/ParsePushTest.php
@@ -20,7 +20,8 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
         Helper::tearDown();
     }
 
-    public function testNoMasterKey() {
+    public function testNoMasterKey()
+    {
         $this->setExpectedException('\Parse\ParseException');
 
         ParsePush::send(
@@ -37,8 +38,9 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             [
             'channels' => [''],
             'data'     => ['alert' => 'sample message'],
-            ]
-        , true);
+            ],
+            true
+        );
     }
 
     /**
@@ -46,15 +48,16 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingWhereAndChannels()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            "Sending a push requires either \"channels\" or a \"where\" query.");
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "Sending a push requires either \"channels\" or a \"where\" query."
+        );
 
         ParsePush::send([
             'data'  => [
                 'alert' => 'are we missing something?'
             ]
         ], true);
-
     }
 
     /**
@@ -62,8 +65,10 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
      */
     public function testWhereAndChannels()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            "Channels and query can not be set at the same time.");
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "Channels and query can not be set at the same time."
+        );
 
         $query = ParseInstallation::query();
         $query->equalTo('key', 'value');
@@ -78,7 +83,6 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             ],
             'where'     => $query
         ], true);
-
     }
 
     public function testPushToQuery()
@@ -89,9 +93,9 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             [
             'data'  => ['alert' => 'iPhone 5 is out!'],
             'where' => $query,
-            ]
-        , true);
-
+            ],
+            true
+        );
     }
 
     public function testPushToQueryWithoutWhere()
@@ -101,22 +105,24 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             [
                 'data'  => ['alert' => 'Done without conditions!'],
                 'where' => $query,
-            ]
-            , true);
-
+            ],
+            true
+        );
     }
 
     public function testNonQueryWhere()
     {
-        $this->setExpectedException('\Exception',
-            'Where parameter for Parse Push must be of type ParseQuery');
+        $this->setExpectedException(
+            '\Exception',
+            'Where parameter for Parse Push must be of type ParseQuery'
+        );
         ParsePush::send(
             [
                 'data'  => ['alert' => 'Will this really work?'],
                 'where' => 'not-a-query',
-            ]
-            , true);
-
+            ],
+            true
+        );
     }
 
     public function testPushDates()
@@ -127,14 +133,17 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
                 'push_time'       => new \DateTime(),
                 'expiration_time' => new \DateTime(),
                 'channels'        => [],
-            ]
-        , true);
+            ],
+            true
+        );
     }
 
     public function testExpirationTimeAndIntervalSet()
     {
-        $this->setExpectedException('\Exception',
-            'Both expiration_time and expiration_interval can\'t be set.');
+        $this->setExpectedException(
+            '\Exception',
+            'Both expiration_time and expiration_interval can\'t be set.'
+        );
         ParsePush::send(
             [
                 'data'            => ['alert' => 'iPhone 5 is out!'],
@@ -142,9 +151,9 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
                 'expiration_time' => new \DateTime(),
                 'expiration_interval'   => 90,
                 'channels'        => [],
-            ]
-            , true);
-
+            ],
+            true
+        );
     }
 
     /**
@@ -156,12 +165,12 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             [
                 'channels' => [''],
                 'data'     => ['alert' => 'sample message'],
-            ]
-        , true);
+            ],
+            true
+        );
 
         // verify headers are present
         $this->assertArrayHasKey('_headers', $response);
-
     }
 
     /**
@@ -177,8 +186,9 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             [
                 'channels' => [''],
                 'data'     => $payload,
-            ]
-            , true);
+            ],
+            true
+        );
 
         // verify push status id is present
         $this->assertTrue(isset($response['_headers']['X-Parse-Push-Status-Id']));
@@ -192,8 +202,10 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($pushStatus);
 
         // verify values
-        $this->assertTrue($pushStatus->getPushTime() instanceof \DateTime,
-            'Push time was not as expected');
+        $this->assertTrue(
+            $pushStatus->getPushTime() instanceof \DateTime,
+            'Push time was not as expected'
+        );
 
         $query = $pushStatus->getPushQuery();
         $options = $query->_getOptions();
@@ -208,12 +220,18 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
         ], $options);
 
         // verify payload
-        $this->assertEquals($payload, $pushStatus->getPushPayload(),
-            'Payload did not match');
+        $this->assertEquals(
+            $payload,
+            $pushStatus->getPushPayload(),
+            'Payload did not match'
+        );
 
         // verify source
-        $this->assertEquals("rest", $pushStatus->getPushSource(),
-            'Source was not rest');
+        $this->assertEquals(
+            "rest",
+            $pushStatus->getPushSource(),
+            'Source was not rest'
+        );
 
         // verify not scheduled
         $this->assertFalse($pushStatus->isScheduled());
@@ -222,24 +240,33 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($pushStatus->isPending());
 
         // verify 'running'
-        $this->assertTrue($pushStatus->isRunning(),
-            'Push did not succeed');
+        $this->assertTrue(
+            $pushStatus->isRunning(),
+            'Push did not succeed'
+        );
 
 
 
         // verify # sent & failed
-        $this->assertEquals(0, $pushStatus->getPushesSent(),
-            'More than 0 pushes sent');
-        $this->assertEquals(0, $pushStatus->getPushesFailed(),
-            'More than 0 pushes failed');
+        $this->assertEquals(
+            0,
+            $pushStatus->getPushesSent(),
+            'More than 0 pushes sent'
+        );
+        $this->assertEquals(
+            0,
+            $pushStatus->getPushesFailed(),
+            'More than 0 pushes failed'
+        );
 
-        $this->assertNotNull($pushStatus->getPushHash(),
-            'Hash not present');
+        $this->assertNotNull(
+            $pushStatus->getPushHash(),
+            'Hash not present'
+        );
 
         // verify we have neither failed or succeeded
         $this->assertFalse($pushStatus->hasFailed());
         $this->assertFalse($pushStatus->hasSucceeded());
-
     }
 
     /**
@@ -249,13 +276,11 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
     {
         $pushStatus = ParsePushStatus::getFromId('not-a-real-id');
         $this->assertNull($pushStatus);
-
     }
 
     public function testDoesNotHaveStatus()
     {
         $this->assertFalse(ParsePush::hasStatus([]));
-
     }
 
     public function testGetStatus()
@@ -274,6 +299,5 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
                 'X-Parse-Push-Status-Id'    => 'not-a-real-id'
             ]
         ]));
-
     }
 }

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -173,7 +173,6 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
             'bar0',
             'EndsWith function did not return the correct object.'
         );
-
     }
 
     public function testStartsWithSingle()
@@ -212,9 +211,8 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
 
         $user = ParseUser::getCurrentUser();
 
-        if(isset($user)) {
+        if (isset($user)) {
             throw new ParseException($user->_encode());
-
         }
 
         $this->provideTestObjects(10);
@@ -1604,13 +1602,12 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         $numbers = [3, 1, 2];
         $objects = [];
 
-        foreach($numbers as $num) {
+        foreach ($numbers as $num) {
             $obj = ParseObject::create('TestObject');
             $obj->set('number', $num);
             $obj->save();
             $objects[]  = $obj;
             sleep(1);
-
         }
 
         $objects[1]->set('number', 4);
@@ -1642,13 +1639,12 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         $numbers = [3, 1, 2];
         $objects = [];
 
-        foreach($numbers as $num) {
+        foreach ($numbers as $num) {
             $obj = ParseObject::create('TestObject');
             $obj->set('number', $num);
             $obj->save();
             $objects[]  = $obj;
             sleep(1);
-
         }
 
         $objects[1]->set('number', 4);
@@ -2213,7 +2209,8 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $count);
     }
 
-    public function testAscendingByArray() {
+    public function testAscendingByArray()
+    {
         $obj = new ParseObject('TestObject');
         $obj->set('name', 'John');
         $obj->set('country', 'US');
@@ -2238,18 +2235,18 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Joel', $results[0]->name);
         $this->assertEquals('Bob', $results[1]->name);
         $this->assertEquals('John', $results[2]->name);
-
     }
 
     public function testOrQueriesVaryingClasses()
     {
-        $this->setExpectedException('\Exception',
-            'All queries must be for the same class');
+        $this->setExpectedException(
+            '\Exception',
+            'All queries must be for the same class'
+        );
         ParseQuery::orQueries([
             new ParseQuery('Class1'),
             new ParseQuery('Class2')
         ]);
-
     }
 
     /**
@@ -2275,11 +2272,12 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
 
     public function testBadConditions()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            "Conditions must be in an array");
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "Conditions must be in an array"
+        );
 
         $query = new ParseQuery('TestObject');
         $query->_setConditions('not-an-array');
-
     }
 }

--- a/tests/Parse/ParseRelationOperationTest.php
+++ b/tests/Parse/ParseRelationOperationTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\Internal\ParseRelationOperation;
 use Parse\ParseObject;
 use Parse\ParseRelation;
@@ -30,10 +29,11 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingObjects()
     {
-        $this->setExpectedException('\Exception',
-            'Cannot create a ParseRelationOperation with no objects.');
+        $this->setExpectedException(
+            '\Exception',
+            'Cannot create a ParseRelationOperation with no objects.'
+        );
         new ParseRelationOperation(null, null);
-
     }
 
     /**
@@ -41,15 +41,16 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMixedClasses()
     {
-        $this->setExpectedException('\Exception',
-            'All objects in a relation must be of the same class.');
+        $this->setExpectedException(
+            '\Exception',
+            'All objects in a relation must be of the same class.'
+        );
 
         $objects = [];
         $objects[] = new ParseObject('Class1');
         $objects[] = new ParseObject('Class2');
 
         new ParseRelationOperation($objects, null);
-
     }
 
     /**
@@ -66,11 +67,10 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
 
         $encoded = $op->_encode();
 
-        $this->assertEquals('AddRelation' ,$encoded['ops'][0]['__op']);
-        $this->assertEquals('RemoveRelation' ,$encoded['ops'][1]['__op']);
+        $this->assertEquals('AddRelation', $encoded['ops'][0]['__op']);
+        $this->assertEquals('RemoveRelation', $encoded['ops'][1]['__op']);
 
         ParseObject::destroyAll([$addObj, $delObj]);
-
     }
 
     /**
@@ -78,17 +78,18 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testApplyDifferentClassRelation()
     {
-        $this->setExpectedException('\Exception',
+        $this->setExpectedException(
+            '\Exception',
             'Related object object must be of class '
             .'Class1, but DifferentClass'
-            .' was passed in.');
+            .' was passed in.'
+        );
 
         // create one op
         $addObj = new ParseObject('Class1');
         $relOp1 = new ParseRelationOperation($addObj, null);
 
         $relOp1->_apply(new ParseRelation(null, null, 'DifferentClass'), null, null);
-
     }
 
     /**
@@ -96,12 +97,13 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidApply()
     {
-        $this->setExpectedException('\Exception',
-            'Operation is invalid after previous operation.');
+        $this->setExpectedException(
+            '\Exception',
+            'Operation is invalid after previous operation.'
+        );
         $addObj = new ParseObject('Class1');
         $op = new ParseRelationOperation($addObj, null);
         $op->_apply('bad value', null, null);
-
     }
 
     /**
@@ -112,7 +114,6 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
         $addObj = new ParseObject('Class1');
         $op = new ParseRelationOperation($addObj, null);
         $this->assertEquals($op, $op->_mergeWithPrevious(null));
-
     }
 
     /**
@@ -120,10 +121,12 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMergeDifferentClass()
     {
-        $this->setExpectedException('\Exception',
+        $this->setExpectedException(
+            '\Exception',
             'Related object object must be of class '
             .'Class1, but AnotherClass'
-            .' was passed in.');
+            .' was passed in.'
+        );
 
         $addObj = new ParseObject('Class1');
         $op = new ParseRelationOperation($addObj, null);
@@ -132,7 +135,6 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
         $mergeOp = new ParseRelationOperation($diffObj, null);
 
         $this->assertEquals($op, $op->_mergeWithPrevious($mergeOp));
-
     }
 
     /**
@@ -140,12 +142,13 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->setExpectedException('\Exception',
-            'Operation is invalid after previous operation.');
+        $this->setExpectedException(
+            '\Exception',
+            'Operation is invalid after previous operation.'
+        );
         $obj = new ParseObject('Class1');
         $op = new ParseRelationOperation($obj, null);
         $op->_mergeWithPrevious('not a relational op');
-
     }
 
     /**
@@ -160,6 +163,5 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
         ParseRelationOperation::removeElementsFromArray('removeThis', $array);
 
         $this->assertEmpty($array);
-
     }
 }

--- a/tests/Parse/ParseRelationTest.php
+++ b/tests/Parse/ParseRelationTest.php
@@ -186,7 +186,6 @@ class ParseRelationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($children));
         $this->assertEquals('child3', $children[0]->get('name'));
-
     }
 
     /**
@@ -216,7 +215,5 @@ class ParseRelationTest extends \PHPUnit_Framework_TestCase
 
         $child2->save();
         $parent->save();
-
     }
-
 }

--- a/tests/Parse/ParseRoleTest.php
+++ b/tests/Parse/ParseRoleTest.php
@@ -91,10 +91,11 @@ class ParseRoleTest extends \PHPUnit_Framework_TestCase
         $role = ParseRole::createRole('Admin', $this->aclPublic());
         $role->save();
         $role2 = ParseRole::createRole('Admin', $this->aclPublic());
-        $this->setExpectedException('Parse\ParseException',
-            "Cannot add duplicate role name of 'Admin'");
+        $this->setExpectedException(
+            'Parse\ParseException',
+            "Cannot add duplicate role name of 'Admin'"
+        );
         $role2->save();
-
     }
 
     /**
@@ -164,7 +165,6 @@ class ParseRoleTest extends \PHPUnit_Framework_TestCase
         $roleAgain->save();
 
         ParseUser::logOut();
-
     }
 
     /**
@@ -235,11 +235,12 @@ class ParseRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testSettingNonStringAsName()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            "A role's name must be a string.");
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "A role's name must be a string."
+        );
         $role = new ParseRole();
         $role->setName(12345);
-
     }
 
     /**
@@ -247,11 +248,12 @@ class ParseRoleTest extends \PHPUnit_Framework_TestCase
      */
     public function testSavingWithoutName()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'Roles must have a name.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'Roles must have a name.'
+        );
         $role = new ParseRole();
         $role->setACL(new ParseACL());
         $role->save();
-
     }
 }

--- a/tests/Parse/ParseSchemaTest.php
+++ b/tests/Parse/ParseSchemaTest.php
@@ -39,7 +39,6 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
         self::$schema = new ParseSchema('SchemaTest');
         Helper::clearClass('_User');
         Helper::setHttpClient();
-
     }
 
     public function tearDown()
@@ -159,7 +158,6 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertNotNull($result['fields']['quantity']);
         $this->assertNotNull($result['fields']['status']);
-
     }
 
     public function testUpdateSchemaCurl()
@@ -184,7 +182,6 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertNotNull($result['fields']['quantity']);
         $this->assertNotNull($result['fields']['status']);
-
     }
 
     public function testUpdateWrongFieldType()
@@ -205,8 +202,10 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
         $deleteSchema->delete();
 
         $getSchema = new ParseSchema('SchemaDeleteTest');
-        $this->setExpectedException('Parse\ParseException',
-            'Class SchemaDeleteTest does not exist.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Class SchemaDeleteTest does not exist.'
+        );
         $getSchema->get();
     }
 
@@ -343,7 +342,6 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
 
         $schema = new ParseSchema(self::$badClassName);
         $schema->get();
-
     }
 
     /**
@@ -360,7 +358,6 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
 
         $schema = new ParseSchema(self::$badClassName);
         $schema->save();
-
     }
 
     /**
@@ -377,7 +374,6 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
 
         $schema = new ParseSchema(self::$badClassName);
         $schema->update();
-
     }
 
     /**
@@ -394,7 +390,5 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
 
         $schema = new ParseSchema(self::$badClassName);
         $schema->delete();
-
     }
-
 }

--- a/tests/Parse/ParseSessionStorageAltTest.php
+++ b/tests/Parse/ParseSessionStorageAltTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\ParseException;
 use Parse\ParseSessionStorage;
 
@@ -19,9 +18,10 @@ class ParseSessionStorageAltTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoSessionActive()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'PHP session_start() must be called first.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'PHP session_start() must be called first.'
+        );
         new ParseSessionStorage();
-
     }
 }

--- a/tests/Parse/ParseSessionStorageTest.php
+++ b/tests/Parse/ParseSessionStorageTest.php
@@ -84,7 +84,6 @@ class ParseSessionStorageTest extends \PHPUnit_Framework_TestCase
     {
         // does nothing
         self::$parseStorage->save();
-
     }
 
     /**
@@ -99,6 +98,5 @@ class ParseSessionStorageTest extends \PHPUnit_Framework_TestCase
         new ParseSessionStorage();
 
         $this->assertEmpty($_SESSION['parseData']);
-
     }
 }

--- a/tests/Parse/ParseStreamHttpClientTest.php
+++ b/tests/Parse/ParseStreamHttpClientTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\HttpClients\ParseStreamHttpClient;
 use Parse\ParseClient;
 use Parse\ParseException;
@@ -27,16 +26,17 @@ class ParseStreamHttpClientTest extends \PHPUnit_Framework_TestCase
         $headers = $client->getResponseHeaders();
 
         $this->assertEquals('HTTP/1.0 200 OK', $headers['http_code']);
-
     }
 
     public function testInvalidUrl()
     {
         $url = 'http://example.com/lots of spaces here';
 
-        $this->setExpectedException('\Parse\ParseException',
+        $this->setExpectedException(
+            '\Parse\ParseException',
             'Url may not contain spaces for stream client: '
-            .$url);
+            .$url
+        );
 
         $client = new ParseStreamHttpClient();
         $client->send($url);

--- a/tests/Parse/ParseUserTest.php
+++ b/tests/Parse/ParseUserTest.php
@@ -83,64 +83,82 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLoginWithFacebook()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Facebook auth is invalid for this user.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Facebook auth is invalid for this user.'
+        );
         $user = ParseUser::logInWithFacebook('asdf', 'zxcv');
     }
 
     public function testLoginWithFacebookNoId()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot log in Facebook user without an id.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot log in Facebook user without an id.'
+        );
         $user = ParseUser::logInWithFacebook(null, 'asdf');
     }
 
     public function testLoginWithFacebookNoAccessToken()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot log in Facebook user without an access token.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot log in Facebook user without an access token.'
+        );
         $user = ParseUser::logInWithFacebook('asdf', null);
     }
 
     public function testLoginWithTwitter()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Twitter auth is invalid for this user.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Twitter auth is invalid for this user.'
+        );
         $user = ParseUser::logInWithTwitter('asdf', 'asdf', 'asdf', null, 'bogus', 'bogus');
     }
 
     public function testLoginWithTwitterNoId()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot log in Twitter user without an id.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot log in Twitter user without an id.'
+        );
         $user = ParseUser::logInWithTwitter(null, 'asdf', 'asdf', null, 'bogus', 'bogus');
     }
 
     public function testLoginWithTwitterNoScreenName()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot log in Twitter user without Twitter screen name.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot log in Twitter user without Twitter screen name.'
+        );
         $user = ParseUser::logInWithTwitter('asdf', null, 'asdf', null, 'bogus', 'bogus');
     }
 
     public function testLoginWithTwitterNoConsumerKey()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot log in Twitter user without a consumer key.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot log in Twitter user without a consumer key.'
+        );
         $user = ParseUser::logInWithTwitter('asdf', 'asdf', null, null, 'bogus', 'bogus');
     }
 
     public function testLoginWithTwitterNoAuthToken()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot log in Twitter user without an auth token.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot log in Twitter user without an auth token.'
+        );
         $user = ParseUser::logInWithTwitter('asdf', 'asdf', 'asdf', null, null, 'bogus');
     }
 
     public function testLoginWithTwitterNoAuthTokenSecret()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot log in Twitter user without an auth token secret.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot log in Twitter user without an auth token secret.'
+        );
         $user = ParseUser::logInWithTwitter('asdf', 'asdf', 'asdf', null, 'bogus', null);
     }
 
@@ -152,8 +170,10 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkWithFacebook()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Facebook auth is invalid for this user.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Facebook auth is invalid for this user.'
+        );
         $this->testUserSignUp();
         $user = ParseUser::logIn('asdf', 'zxcv');
         $user->linkWithFacebook('asdf', 'zxcv');
@@ -161,16 +181,20 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkWithFacebookUnsavedUser()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot link an unsaved user, use ParseUser::logInWithFacebook');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot link an unsaved user, use ParseUser::logInWithFacebook'
+        );
         $user = new ParseUser();
         $user->linkWithFacebook('asdf', 'zxcv');
     }
 
     public function testLinkWithFacebookNoId()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot link Facebook user without an id.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot link Facebook user without an id.'
+        );
         $this->testUserSignUp();
         $user = ParseUser::logIn('asdf', 'zxcv');
         $user->linkWithFacebook(null, 'zxcv');
@@ -178,8 +202,10 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkWithFacebookNoAccessToken()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot link Facebook user without an access token.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot link Facebook user without an access token.'
+        );
         $this->testUserSignUp();
         $user = ParseUser::logIn('asdf', 'zxcv');
         $user->linkWithFacebook('asdf', null);
@@ -187,8 +213,10 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkWithTwitter()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Twitter auth is invalid for this user.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Twitter auth is invalid for this user.'
+        );
         $this->testUserSignUp();
         $user = ParseUser::logIn('asdf', 'zxcv');
         $user->linkWithTwitter('qwer', 'asdf', 'zxcv', null, 'bogus', 'bogus');
@@ -196,16 +224,20 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkWithTwitterUnsavedUser()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot link an unsaved user, use ParseUser::logInWithTwitter');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot link an unsaved user, use ParseUser::logInWithTwitter'
+        );
         $user = new ParseUser();
         $user->linkWithTwitter('qwer', 'asdf', 'zxcv', null, 'bogus', 'bogus');
     }
 
     public function testLinkWithTwitterNoId()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot link Twitter user without an id.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot link Twitter user without an id.'
+        );
         $this->testUserSignUp();
         $user = ParseUser::logIn('asdf', 'zxcv');
         $user->linkWithTwitter(null, 'asdf', 'zxcv', null, 'bogus', 'bogus');
@@ -213,8 +245,10 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkWithTwitterNoScreenName()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot link Twitter user without Twitter screen name.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot link Twitter user without Twitter screen name.'
+        );
         $this->testUserSignUp();
         $user = ParseUser::logIn('asdf', 'zxcv');
         $user->linkWithTwitter('qwer', null, 'zxcv', null, 'bogus', 'bogus');
@@ -222,8 +256,10 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkWithTwitterNoConsumerKey()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot link Twitter user without a consumer key.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot link Twitter user without a consumer key.'
+        );
         $this->testUserSignUp();
         $user = ParseUser::logIn('asdf', 'zxcv');
         $user->linkWithTwitter('qwer', 'asdf', null, null, 'bogus', 'bogus');
@@ -231,8 +267,10 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkWithTwitterNoAuthToken()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot link Twitter user without an auth token.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot link Twitter user without an auth token.'
+        );
         $this->testUserSignUp();
         $user = ParseUser::logIn('asdf', 'zxcv');
         $user->linkWithTwitter('qwer', 'asdf', 'zxcv', null, null, 'bogus');
@@ -240,8 +278,10 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkWithTwitterNoAuthTokenSecret()
     {
-        $this->setExpectedException('Parse\ParseException',
-                'Cannot link Twitter user without an auth token secret.');
+        $this->setExpectedException(
+            'Parse\ParseException',
+            'Cannot link Twitter user without an auth token secret.'
+        );
         $this->testUserSignUp();
         $user = ParseUser::logIn('asdf', 'zxcv');
         $user->linkWithTwitter('qwer', 'asdf', 'zxcv', null, 'bogus', null);
@@ -638,7 +678,6 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
         $user = ParseUser::loginWithAnonymous();
         $this->assertEquals(ParseUser::getCurrentUser(), $user);
         ParseUser::logOut();
-
     }
 
     /**
@@ -660,7 +699,7 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(ParseUser::getCurrentUser());
 
-        $storage->set('user',[
+        $storage->set('user', [
             'id'            => $id,
             '_sessionToken' => $sessionToken,
             'moredata'      => 'moredata'
@@ -678,6 +717,5 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('moredata', $currentUser->get('moredata'));
 
         ParseUser::logOut();
-
     }
 }

--- a/tests/Parse/RemoveOperationTest.php
+++ b/tests/Parse/RemoveOperationTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\Internal\AddOperation;
 use Parse\Internal\DeleteOperation;
 use Parse\Internal\RemoveOperation;
@@ -22,10 +21,11 @@ class RemoveOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingArray()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'RemoveOperation requires an array.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'RemoveOperation requires an array.'
+        );
         new RemoveOperation('not an array');
-
     }
 
     /**
@@ -57,7 +57,6 @@ class RemoveOperationTest extends \PHPUnit_Framework_TestCase
             'key2'  => 'value2',
             'key1'  => 'value1'
         ], $merged->getValue(), 'Value was not as expected');
-
     }
 
     /**
@@ -65,13 +64,14 @@ class RemoveOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->setExpectedException('\Parse\ParseException',
-            'Operation is invalid after previous operation.');
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            'Operation is invalid after previous operation.'
+        );
         $removeOp = new RemoveOperation([
             'key1'          => 'value1'
         ]);
         $removeOp->_mergeWithPrevious(new AddOperation(['key'=>'value']));
-
     }
 
     /**
@@ -83,6 +83,5 @@ class RemoveOperationTest extends \PHPUnit_Framework_TestCase
             'key1'          => 'value1'
         ]);
         $this->assertEmpty($removeOp->_apply([], null, null));
-
     }
 }


### PR DESCRIPTION
I've added a few commands to the package.json file.

`npm test` - shortcut for tests
`npm run test:coverage` - for travis
`npm run lint` - Lints src and test folders
`npm run lint:fix` - Automatically Lints files

I've also forced travis to lint files.

`CONTIBUTING.md` has been updated

I have phpcs already installed on my text editor so I thought it would be nice to have in this project.