### PR TITLE
Corrects and updates phpdoc references/errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ phpunit-test-results
 *.log
 
 coverage.xml
+
+# ignore phpdoc
+output/

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "squizlabs/php_codesniffer": "^3.0.1",
-        "phpdocumentor/phpdocumentor": "~2.5"
+        "phpdocumentor/phpdocumentor": "~2.9"
     },
     "autoload": {
         "psr-4": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint": "./vendor/bin/phpcs --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "lint:fix": "./vendor/bin/phpcbf --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "start" : "./node_modules/parse-server-test/run-server",
-    "stop"  : "./node_modules/parse-server-test/stop-server"
+    "stop"  : "./node_modules/parse-server-test/stop-server",
+    "document" : "./vendor/bin/phpdoc -d ./src/ --title 'Parse PHP SDK API Reference' --template='responsive-twig'"
   },
   "repository": {
     "type": "git",

--- a/src/Parse/HttpClients/ParseCurl.php
+++ b/src/Parse/HttpClients/ParseCurl.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * ParseCurl - Wrapper for abstracted curl usage
- *
- * @author Ben Friedman <ben@axolsoft.com>
+ * Class ParseCurl | Parse/HttpClients/ParseCurl.php
  */
 
 namespace Parse\HttpClients;
@@ -10,13 +8,16 @@ namespace Parse\HttpClients;
 use Parse\ParseException;
 
 /**
- * Class ParseCurl
+ * Class ParseCurl - Wrapper for abstracted curl usage
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
  * @package Parse\HttpClients
  */
 class ParseCurl
 {
     /**
      * Curl handle
+     *
      * @var resource
      */
     private $curl;

--- a/src/Parse/HttpClients/ParseCurlHttpClient.php
+++ b/src/Parse/HttpClients/ParseCurlHttpClient.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * ParseCurlHttpClient - Curl http client
- *
- * @author Ben Friedman <ben@axolsoft.com>
+ * Class ParseCurlHttpClient | Parse/HttpClients/ParseCurlHttpClient.php
  */
 
 namespace Parse\HttpClients;
@@ -10,49 +8,58 @@ namespace Parse\HttpClients;
 use Parse\ParseException;
 
 /**
- * Class ParseCurlHttpClient
+ * Class ParseCurlHttpClient - Curl http client
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
  * @package Parse\HttpClients
  */
 class ParseCurlHttpClient implements ParseHttpable
 {
     /**
      * Curl handle
+     *
      * @var ParseCurl
      */
     private $parseCurl;
 
     /**
      * Request Headers
+     *
      * @var array
      */
     private $headers = array();
 
     /**
      * Response headers
+     *
      * @var array
      */
     private $responseHeaders = array();
 
     /**
      * Response code
+     *
      * @var int
      */
     private $responseCode = 0;
 
     /**
      * Content type of our response
+     *
      * @var string|null
      */
     private $responseContentType;
 
     /**
      * cURL error code
+     *
      * @var int
      */
     private $curlErrorCode;
 
     /**
      * cURL error message
+     *
      * @var string
      */
     private $curlErrorMessage;
@@ -69,11 +76,14 @@ class ParseCurlHttpClient implements ParseHttpable
 
     /**
      * Response from our request
+     *
      * @var string
      */
     private $response;
 
-
+    /**
+     * ParseCurlHttpClient constructor.
+     */
     public function __construct()
     {
         if (!isset($this->parseCurl)) {

--- a/src/Parse/HttpClients/ParseHttpable.php
+++ b/src/Parse/HttpClients/ParseHttpable.php
@@ -1,12 +1,16 @@
 <?php
 /**
- * ParseHttpable - Interface for an HTTPable client
- *
- * @author Ben Friedman <ben@axolsoft.com>
+ * Class ParseHttpable | Parse/HttpClients/ParseHttpable.php
  */
 
 namespace Parse\HttpClients;
 
+/**
+ * Class ParseHttpable - Interface for an HTTPable client
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
+ * @package Parse\HttpClients
+ */
 interface ParseHttpable
 {
     /**

--- a/src/Parse/HttpClients/ParseStream.php
+++ b/src/Parse/HttpClients/ParseStream.php
@@ -1,19 +1,20 @@
 <?php
 /**
- * ParseStream - Wrapper for abstracted stream usage
- *
- * @author Ben Friedman <ben@axolsoft.com>
+ * Class ParseStream | Parse/HttpClients/ParseStream.php
  */
 
 namespace Parse\HttpClients;
 
 /**
- * Class ParseStream
+ * Class ParseStream - Wrapper for abstracted stream usage
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
  * @package Parse\HttpClients
  */
 class ParseStream
 {
     /**
+     * Stream context
      *
      * @var resource
      */
@@ -21,18 +22,21 @@ class ParseStream
 
     /**
      * Response headers
+     *
      * @var array|null
      */
     private $responseHeaders;
 
     /**
      * Error message
+     *
      * @var string
      */
     private $errorMessage;
 
     /**
      * Error code
+     *
      * @var int
      */
     private $errorCode;

--- a/src/Parse/HttpClients/ParseStreamHttpClient.php
+++ b/src/Parse/HttpClients/ParseStreamHttpClient.php
@@ -1,76 +1,93 @@
 <?php
 /**
- * ParseStreamHttpClient - Stream http client
- *
- * @author Ben Friedman <ben@axolsoft.com>
+ * Class ParseStreamHttpClient | Parse/HttpClients/ParseStreamHttpClient.php
  */
 
 namespace Parse\HttpClients;
 
 use Parse\ParseException;
 
+/**
+ * Class ParseStreamHttpClient - Stream http client
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
+ * @package Parse\HttpClients
+ */
 class ParseStreamHttpClient implements ParseHttpable
 {
     /**
      * Stream handle
+     *
      * @var ParseStream
      */
     private $parseStream;
 
     /**
      * Request Headers
+     *
      * @var array
      */
     private $headers = array();
 
     /**
      * Response headers
+     *
      * @var array
      */
     private $responseHeaders = array();
 
     /**
      * Response code
+     *
      * @var int
      */
     private $responseCode = 0;
 
     /**
      * Content type of our response
+     *
      * @var string|null
      */
     private $responseContentType;
 
     /**
      * Stream error code
+     *
      * @var int
      */
     private $streamErrorCode;
 
     /**
      * Stream error message
+     *
      * @var string
      */
     private $streamErrorMessage;
 
     /**
      * Options to pass to our stream
+     *
      * @var array
      */
     private $options = array();
 
     /**
      * Optional CA file to verify our peers with
+     *
      * @var string
      */
     private $caFile;
 
     /**
      * Response from our request
+     *
      * @var string
      */
     private $response;
 
+    /**
+     * ParseStreamHttpClient constructor.
+     */
     public function __construct()
     {
         if (!isset($this->parseStream)) {
@@ -143,6 +160,9 @@ class ParseStreamHttpClient implements ParseHttpable
         return implode("\r\n", $headers);
     }
 
+    /**
+     * Sets up ssl related options for the stream context
+     */
     public function setup()
     {
         // setup ssl options
@@ -154,6 +174,15 @@ class ParseStreamHttpClient implements ParseHttpable
         );
     }
 
+    /**
+     * Sends an HTTP request
+     *
+     * @param string $url       Url to send this request to
+     * @param string $method    Method to send this request via
+     * @param array $data       Data to send in this request
+     * @return string
+     * @throws ParseException
+     */
     public function send($url, $method = 'GET', $data = array())
     {
 
@@ -287,6 +316,11 @@ class ParseStreamHttpClient implements ParseHttpable
         return $this->streamErrorMessage;
     }
 
+    /**
+     * Sets a connection timeout. UNUSED in the stream client.
+     *
+     * @param int $timeout  Timeout to set
+     */
     public function setConnectionTimeout($timeout)
     {
         // do nothing

--- a/src/Parse/Internal/AddOperation.php
+++ b/src/Parse/Internal/AddOperation.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class AddOperation | Parse/Internal/AddOperation.php
+ */
 
 namespace Parse\Internal;
 
@@ -9,6 +12,7 @@ use Parse\ParseException;
  * Class AddOperation - FieldOperation for adding object(s) to array fields.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse\Internal
  */
 class AddOperation implements FieldOperation
 {

--- a/src/Parse/Internal/AddUniqueOperation.php
+++ b/src/Parse/Internal/AddUniqueOperation.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class AddUniqueOperation | Parse/Internal/AddUniqueOperation.php
+ */
 
 namespace Parse\Internal;
 
@@ -10,6 +13,7 @@ use Parse\ParseObject;
  * Class AddUniqueOperation - Operation to add unique objects to an array key.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse\Internal
  */
 class AddUniqueOperation implements FieldOperation
 {
@@ -126,6 +130,13 @@ class AddUniqueOperation implements FieldOperation
         return $oldValue;
     }
 
+    /**
+     * Checks if a parse object is contained in a given array of values
+     *
+     * @param ParseObject $parseObject  ParseObject to check for existence of
+     * @param array $oldValue           Array to check if ParseObject is present in
+     * @return bool
+     */
     private function isParseObjectInArray($parseObject, $oldValue)
     {
         foreach ($oldValue as $object) {

--- a/src/Parse/Internal/DeleteOperation.php
+++ b/src/Parse/Internal/DeleteOperation.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class DeleteOperation | Parse/Internal/DeleteOperation.php
+ */
 
 namespace Parse\Internal;
 
@@ -6,6 +9,7 @@ namespace Parse\Internal;
  * Class DeleteOperation - FieldOperation to remove a key from an object.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse\Internal
  */
 class DeleteOperation implements FieldOperation
 {

--- a/src/Parse/Internal/Encodable.php
+++ b/src/Parse/Internal/Encodable.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class Encodable | Parse/Internal/Encodable.php
+ */
 
 namespace Parse\Internal;
 
@@ -7,6 +10,7 @@ namespace Parse\Internal;
  * method.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse\Internal
  */
 interface Encodable
 {

--- a/src/Parse/Internal/FieldOperation.php
+++ b/src/Parse/Internal/FieldOperation.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class FieldOperation | Parse/Internal/FieldOperation.php
+ */
 
 namespace Parse\Internal;
 
@@ -6,6 +9,7 @@ namespace Parse\Internal;
  * Class FieldOperation - Interface for all Parse Field Operations.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse\Internal
  */
 interface FieldOperation extends Encodable
 {

--- a/src/Parse/Internal/IncrementOperation.php
+++ b/src/Parse/Internal/IncrementOperation.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class IncrementOperation | Parse/Internal/IncrementOperation.php
+ */
 
 namespace Parse\Internal;
 
@@ -8,6 +11,7 @@ use Parse\ParseException;
  * Class IncrementOperation - Operation to increment numeric object key.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse\Internal
  */
 class IncrementOperation implements FieldOperation
 {

--- a/src/Parse/Internal/ParseRelationOperation.php
+++ b/src/Parse/Internal/ParseRelationOperation.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class ParseRelationOperation | Parse/Internal/ParseRelationOperation.php
+ */
 
 namespace Parse\Internal;
 
@@ -8,9 +11,10 @@ use Parse\ParseObject;
 use Parse\ParseRelation;
 
 /**
- * ParseRelationOperation - A class that is used to manage ParseRelation changes such as object add or remove.
+ * Class ParseRelationOperation - A class that is used to manage ParseRelation changes such as object add or remove.
  *
  * @author Mohamed Madbouli <mohamedmadbouli@fb.com>
+ * @package Parse\Internal
  */
 class ParseRelationOperation implements FieldOperation
 {
@@ -35,6 +39,13 @@ class ParseRelationOperation implements FieldOperation
      */
     private $relationsToRemove = [];
 
+    /**
+     * ParseRelationOperation constructor.
+     *
+     * @param ParseObject[] $objectsToAdd       ParseObjects to add
+     * @param ParseObject[] $objectsToRemove    ParseObjects to remove
+     * @throws Exception
+     */
     public function __construct($objectsToAdd, $objectsToRemove)
     {
         $this->targetClassName = null;
@@ -258,6 +269,11 @@ class ParseRelationOperation implements FieldOperation
         return empty($addRelation['objects']) ? $removeRelation : $addRelation;
     }
 
+    /**
+     * Gets the className of the target objects.
+     *
+     * @return null|string
+     */
     public function _getTargetClass()
     {
         return $this->targetClassName;

--- a/src/Parse/Internal/RemoveOperation.php
+++ b/src/Parse/Internal/RemoveOperation.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class RemoveOperation | Parse/Internal/RemoveOperation.php
+ */
 
 namespace Parse\Internal;
 
@@ -11,6 +14,7 @@ use Parse\ParseObject;
  * fields.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse\Internal
  */
 class RemoveOperation implements FieldOperation
 {

--- a/src/Parse/Internal/SetOperation.php
+++ b/src/Parse/Internal/SetOperation.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class SetOperation | Parse/Internal/SetOperation.php
+ */
 
 namespace Parse\Internal;
 
@@ -8,6 +11,7 @@ use Parse\ParseClient;
  * Class SetOperation - Operation to set a value for an object key.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse\Internal
  */
 class SetOperation implements FieldOperation
 {

--- a/src/Parse/ParseACL.php
+++ b/src/Parse/ParseACL.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class ParseACL | Parse/ParseACL.php
+ */
 
 namespace Parse;
 
@@ -6,7 +9,7 @@ use Exception;
 use Parse\Internal\Encodable;
 
 /**
- * ParseACL - is used to control which users can access or modify a particular
+ * Class ParseACL - is used to control which users can access or modify a particular
  * object. Each ParseObject can have its own ParseACL. You can grant read and
  * write permissions separately to specific users, to groups of users that
  * belong to roles, or you can grant permissions to "the public" so that, for
@@ -14,37 +17,50 @@ use Parse\Internal\Encodable;
  * of users could write to that object.
  *
  * @author Mohamed Madbouli <mohamedmadbouli@fb.com>
+ * @package Parse
  */
 class ParseACL implements Encodable
 {
     const PUBLIC_KEY = '*';
 
     /**
+     * Array of permissions by id
+     *
      * @var array
      */
     private $permissionsById = [];
 
     /**
+     * Whether this ACL is shared
+     *
      * @var bool
      */
     private $shared = false;
 
     /**
+     * The last known current user
+     *
      * @var ParseUser
      */
     private static $lastCurrentUser = null;
 
     /**
+     * An ACL with defaults set with the current user
+     *
      * @var ParseACL
      */
     private static $defaultACLWithCurrentUser = null;
 
     /**
+     * An ACL with defaults set
+     *
      * @var ParseACL
      */
     private static $defaultACL = null;
 
     /**
+     * Whether the default acl uses the current user or not
+     *
      * @var bool
      */
     private static $defaultACLUsesCurrentUser = false;
@@ -119,6 +135,11 @@ class ParseACL implements Encodable
         $this->shared = $shared;
     }
 
+    /**
+     * Returns an associate array encoding of this ParseACL instance.
+     *
+     * @return mixed
+     */
     public function _encode()
     {
         if (empty($this->permissionsById)) {

--- a/src/Parse/ParseAggregateException.php
+++ b/src/Parse/ParseAggregateException.php
@@ -1,14 +1,23 @@
 <?php
+/**
+ * Class ParseAggregateException | Parse/ParseAggregateException.php
+ */
 
 namespace Parse;
 
 /**
- * ParseAggregateException - Multiple error condition.
+ * Class ParseAggregateException - Multiple error condition.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseAggregateException extends ParseException
 {
+    /**
+     * Collection of error values
+     *
+     * @var array
+     */
     private $errors;
 
     /**

--- a/src/Parse/ParseAnalytics.php
+++ b/src/Parse/ParseAnalytics.php
@@ -1,13 +1,17 @@
 <?php
+/**
+ * Class ParseAnalytics | Parse/ParseAnalytics.php
+ */
 
 namespace Parse;
 
 use Exception;
 
 /**
- * ParseAnalytics - Handles sending app-open and custom analytics events.
+ * Class ParseAnalytics - Handles sending app-open and custom analytics events.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseAnalytics
 {
@@ -62,6 +66,12 @@ class ParseAnalytics
         );
     }
 
+    /**
+     * Encodes and returns the given data as a json object
+     *
+     * @param array $data   Data to encode
+     * @return string
+     */
     public static function _toSaveJSON($data)
     {
         return json_encode(

--- a/src/Parse/ParseApp.php
+++ b/src/Parse/ParseApp.php
@@ -1,20 +1,59 @@
 <?php
+/**
+ * Class ParseApp | Parse/ParseApp.php
+ */
 
 namespace Parse;
 
+/**
+ * Class ParseApp - Used to manage individual app instances on parse.com.
+ * Note that with the open source parse-server this is not used as each parse-server is a singular app instance.
+ *
+ * @deprecated Not available on the open source parse-server.
+ * @package Parse
+ */
 class ParseApp
 {
+    /**
+     * App name key
+     *
+     * @var string
+     */
     public static $APP_NAME = 'appName';
+
+    /**
+     * Class creation key
+     *
+     * @var string
+     */
     public static $CLIENT_CLASS_CREATION_ENABLED = 'clientClassCreationEnabled';
+
+    /**
+     * Client push enabled key
+     *
+     * @var string
+     */
     public static $CLIENT_PUSH_ENABLED = 'clientPushEnabled';
+
+    /**
+     * Require revocable session key
+     *
+     * @var string
+     */
     public static $REQUIRE_REVOCABLE_SESSION = 'requireRevocableSessions';
+
+    /**
+     * Revoke session on password change key
+     *
+     * @var string
+     */
     public static $REVOKE_SESSION_ON_PASSWORD_CHANGE = 'revokeSessionOnPasswordChange';
 
     /**
      * To fetch the keys and settings for all of the apps that you are a collaborator on.
      *
      * @throws ParseException
-     *
+     * @deprecated Not available on the open source parse-server.
      * @return array Containing the keys and settings for your apps.
      */
     public static function fetchApps()
@@ -37,7 +76,7 @@ class ParseApp
      * @param string $application_id
      *
      * @throws ParseException
-     *
+     * @deprecated Not available on the open source parse-server.
      * @return array Containing the keys and settings for your app.
      */
     public static function fetchApp($application_id)
@@ -60,7 +99,7 @@ class ParseApp
      * @param array $data
      *
      * @throws ParseException
-     *
+     * @deprecated Not available on the open source parse-server.
      * @return array
      */
     public static function createApp(array $data)
@@ -84,7 +123,7 @@ class ParseApp
      * @param array  $data
      *
      * @throws ParseException
-     *
+     * @deprecated Not available on the open source parse-server.
      * @return array
      */
     public static function updateApp($application_id, array $data)

--- a/src/Parse/ParseBytes.php
+++ b/src/Parse/ParseBytes.php
@@ -1,13 +1,17 @@
 <?php
+/**
+ * Class ParseBytes | Parse/ParseBytes.php
+ */
 
 namespace Parse;
 
 use Parse\Internal\Encodable;
 
 /**
- * ParseBytes - Representation of a Byte array for storage on a Parse Object.
+ * Class ParseBytes - Representation of a Byte array for storage on a Parse Object.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseBytes implements Encodable
 {
@@ -48,12 +52,22 @@ class ParseBytes implements Encodable
         return $bytes;
     }
 
+    /**
+     * Decodes and unpacks a given base64 encoded array of data
+     *
+     * @param $base64Data
+     */
     private function setBase64Data($base64Data)
     {
         $byteArray = unpack('C*', base64_decode($base64Data));
         $this->setByteArray($byteArray);
     }
 
+    /**
+     * Sets a new byte array
+     *
+     * @param array $byteArray  Byte array to set
+     */
     private function setByteArray(array $byteArray)
     {
         $this->byteArray = $byteArray;

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class ParseClient | Parse/ParseClient.php
+ */
 
 namespace Parse;
 
@@ -9,9 +12,10 @@ use Parse\HttpClients\ParseStreamHttpClient;
 use Parse\Internal\Encodable;
 
 /**
- * ParseClient - Main class for Parse initialization and communication.
+ * Class ParseClient - Main class for Parse initialization and communication.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 final class ParseClient
 {
@@ -107,7 +111,7 @@ final class ParseClient
     private static $caFile;
 
     /**
-     * Constant for version string to include with requests.
+     * Constant for version string to include with requests. Currently 1.2.9.
      *
      * @var string
      */
@@ -566,6 +570,11 @@ final class ParseClient
         self::$storage = null;
     }
 
+    /**
+     * Asserts that the sdk has been initialized with a valid application id
+     *
+     * @throws Exception
+     */
     private static function assertParseInitialized()
     {
         if (self::$applicationId === null) {
@@ -576,6 +585,8 @@ final class ParseClient
     }
 
     /**
+     * Asserts that the sdk has been initialized with a valid account key
+     *
      * @throws Exception
      */
     private static function assertAppInitialized()

--- a/src/Parse/ParseCloud.php
+++ b/src/Parse/ParseCloud.php
@@ -1,11 +1,15 @@
 <?php
+/**
+ * Class ParseCloud | Parse/ParseCloud.php
+ */
 
 namespace Parse;
 
 /**
- * ParseCloud - Facilitates calling Parse Cloud functions.
+ * Class ParseCloud - Facilitates calling Parse Cloud functions.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseCloud
 {

--- a/src/Parse/ParseConfig.php
+++ b/src/Parse/ParseConfig.php
@@ -1,18 +1,27 @@
 <?php
+/**
+ * Class ParseConfig | Parse/ParseConfig.php
+ */
 
 namespace Parse;
 
 /**
- * ParseConfig - For accessing Parse Config settings.
+ * Class ParseConfig - For accessing Parse Config settings.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseConfig
 {
+    /**
+     * Current configuration data
+     *
+     * @var array
+     */
     private $currentConfig;
 
     /**
-     * Creates.
+     * ParseConfig constructor.
      */
     public function __construct()
     {
@@ -20,6 +29,12 @@ class ParseConfig
         $this->setConfig($result['params']);
     }
 
+    /**
+     * Gets a config value
+     *
+     * @param string $key   Key of value to get
+     * @return mixed
+     */
     public function get($key)
     {
         if (isset($this->currentConfig[$key])) {
@@ -27,6 +42,12 @@ class ParseConfig
         }
     }
 
+    /**
+     * Gets a config value with html characters encoded
+     *
+     * @param string $key   Key of value to get
+     * @return string
+     */
     public function escape($key)
     {
         if (isset($this->currentConfig[$key])) {
@@ -34,11 +55,21 @@ class ParseConfig
         }
     }
 
+    /**
+     * Sets the config
+     *
+     * @param array $config Config to set
+     */
     protected function setConfig($config)
     {
         $this->currentConfig = $config;
     }
 
+    /**
+     * Gets the current config
+     *
+     * @return array
+     */
     public function getConfig()
     {
         return $this->currentConfig;

--- a/src/Parse/ParseException.php
+++ b/src/Parse/ParseException.php
@@ -1,13 +1,17 @@
 <?php
+/**
+ * Class ParseException | Parse/ParseException.php
+ */
 
 namespace Parse;
 
 use Exception;
 
 /**
- * ParseException - Wrapper for \Exception class.
+ * Class ParseException - Wrapper for \Exception class.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseException extends Exception
 {

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -1,13 +1,17 @@
 <?php
+/**
+ * Class ParseFile | Parse/ParseFile.php
+ */
 
 namespace Parse;
 
 use Parse\Internal\Encodable;
 
 /**
- * ParseFile - Representation of a Parse File object.
+ * Class ParseFile - Representation of a Parse File object.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseFile implements Encodable
 {
@@ -230,6 +234,12 @@ class ParseFile implements Encodable
         );
     }
 
+    /**
+     * Attempts to download and return the contents of a ParseFile's url
+     *
+     * @return mixed
+     * @throws ParseException
+     */
     private function download()
     {
         $rest = curl_init();
@@ -251,6 +261,12 @@ class ParseFile implements Encodable
         return $response;
     }
 
+    /**
+     * Returns the mimetype for a given extension
+     *
+     * @param string $extension Extension to return type for
+     * @return string
+     */
     private function getMimeTypeForExtension($extension)
     {
         $knownTypes = [

--- a/src/Parse/ParseGeoPoint.php
+++ b/src/Parse/ParseGeoPoint.php
@@ -1,13 +1,17 @@
 <?php
+/**
+ * Class ParseGeoPoint | Parse/ParseGeoPoint.php
+ */
 
 namespace Parse;
 
 use Parse\Internal\Encodable;
 
 /**
- * ParseGeoPoint - Representation of a Parse GeoPoint object.
+ * Class ParseGeoPoint - Representation of a Parse GeoPoint object.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseGeoPoint implements Encodable
 {

--- a/src/Parse/ParseHooks.php
+++ b/src/Parse/ParseHooks.php
@@ -1,11 +1,15 @@
 <?php
+/**
+ * Class ParseHooks | Parse/ParseHooks.php
+ */
 
 namespace Parse;
 
 /**
- * ParseHooks - Representation of a Parse Hooks object.
+ * Class ParseHooks - Representation of a Parse Hooks object.
  *
  * @author Phelipe Alves <phelipealvessouza@gmail.com>
+ * @package Parse
  */
 class ParseHooks
 {

--- a/src/Parse/ParseInstallation.php
+++ b/src/Parse/ParseInstallation.php
@@ -1,14 +1,23 @@
 <?php
+/**
+ * Class ParseHooks | Parse/ParseHooks.php
+ */
 
 namespace Parse;
 
 /**
- * ParseInstallation - Representation of an Installation stored on Parse.
+ * Class ParseInstallation - Representation of an Installation stored on Parse.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseInstallation extends ParseObject
 {
+    /**
+     * Parse Class name
+     *
+     * @var string
+     */
     public static $parseClassName = '_Installation';
 
     /**

--- a/src/Parse/ParseMemoryStorage.php
+++ b/src/Parse/ParseMemoryStorage.php
@@ -1,30 +1,58 @@
 <?php
+/**
+ * Class ParseMemoryStorage | Parse/ParseMemoryStorage.php
+ */
 
 namespace Parse;
 
 /**
- * ParseMemoryStorage - Uses non-persisted memory for storage.
+ * Class ParseMemoryStorage - Uses non-persisted memory for storage.
  * This is used by default if a PHP Session is not active.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseMemoryStorage implements ParseStorageInterface
 {
     /**
+     * Memory storage
+     *
      * @var array
      */
     private $storage = [];
 
+    /**
+     * Sets a key-value pair in storage.
+     *
+     * @param string $key   The key to set
+     * @param mixed  $value The value to set
+     *
+     * @return void
+     */
     public function set($key, $value)
     {
         $this->storage[$key] = $value;
     }
 
+    /**
+     * Remove a key from storage.
+     *
+     * @param string $key The key to remove.
+     *
+     * @return void
+     */
     public function remove($key)
     {
         unset($this->storage[$key]);
     }
 
+    /**
+     * Gets the value for a key from storage.
+     *
+     * @param string $key The key to get the value for
+     *
+     * @return mixed
+     */
     public function get($key)
     {
         if (isset($this->storage[$key])) {
@@ -34,22 +62,40 @@ class ParseMemoryStorage implements ParseStorageInterface
         return;
     }
 
+    /**
+     * Clear all the values in storage.
+     *
+     * @return null
+     */
     public function clear()
     {
         $this->storage = [];
     }
 
+    /**
+     * Save the data, if necessary. Not implemented.
+     */
     public function save()
     {
         // No action required.
         return;
     }
 
+    /**
+     * Get all keys in storage.
+     *
+     * @return array
+     */
     public function getKeys()
     {
         return array_keys($this->storage);
     }
 
+    /**
+     * Get all key-value pairs from storage.
+     *
+     * @return array
+     */
     public function getAll()
     {
         return $this->storage;

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class ParseObject | Parse/ParseObject.php
+ */
 
 namespace Parse;
 
@@ -13,9 +16,10 @@ use Parse\Internal\RemoveOperation;
 use Parse\Internal\SetOperation;
 
 /**
- * ParseObject - Representation of an object stored on Parse.
+ * Class ParseObject - Representation of an object stored on Parse.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseObject implements Encodable
 {
@@ -259,7 +263,7 @@ class ParseObject implements Encodable
      * Detects if the object (and optionally the child objects) has unsaved
      * changes.
      *
-     * @param $considerChildren
+     * @param bool $considerChildren    Whether to consider children when checking for dirty state
      *
      * @return bool
      */
@@ -270,6 +274,11 @@ class ParseObject implements Encodable
             ($considerChildren && $this->hasDirtyChildren());
     }
 
+    /**
+     * Determines whether this object has child objects that are dirty
+     *
+     * @return bool
+     */
     private function hasDirtyChildren()
     {
         $result = false;
@@ -459,6 +468,12 @@ class ParseObject implements Encodable
         return $this->hasBeenFetched;
     }
 
+    /**
+     * Returns whether or not data is available for a given key
+     *
+     * @param string $key   Key to check availability of
+     * @return bool
+     */
     private function _isDataAvailable($key)
     {
         return $this->isDataAvailable() || isset($this->dataAvailability[$key]);
@@ -543,6 +558,13 @@ class ParseObject implements Encodable
         return static::updateWithFetchedResults($objects, $results);
     }
 
+    /**
+     * Creates an array of object ids from a given array of ParseObjects
+     *
+     * @param array $objects    Objects to create id array from
+     * @return array
+     * @throws ParseException
+     */
     private static function toObjectIdArray(array $objects)
     {
         $objectIds = [];
@@ -564,6 +586,14 @@ class ParseObject implements Encodable
         return $objectIds;
     }
 
+    /**
+     * Merges an existing array of objects with their fetched counterparts
+     *
+     * @param array $objects    Original objects to update
+     * @param array $fetched    Fetched object data to update with
+     * @return array
+     * @throws ParseException
+     */
     private static function updateWithFetchedResults(array $objects, array $fetched)
     {
         $fetchedObjectsById = [];
@@ -1269,7 +1299,7 @@ class ParseObject implements Encodable
     }
 
     /**
-     * Get ACL assigned to the object.
+     * Get the ACL assigned to the object.
      *
      * @return ParseACL
      */
@@ -1278,6 +1308,12 @@ class ParseObject implements Encodable
         return $this->getACLWithCopy(true);
     }
 
+    /**
+     * Internally retrieves the ACL assigned to this object, conditionally returning a copy of the existing one
+     *
+     * @param bool $mayCopy Whether to return a copy of this acl or not
+     * @return ParseACL
+     */
     private function getACLWithCopy($mayCopy)
     {
         if (!isset($this->estimatedData['ACL'])) {
@@ -1289,6 +1325,7 @@ class ParseObject implements Encodable
         }
 
         return $acl;
+
     }
 
     /**

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -1325,7 +1325,6 @@ class ParseObject implements Encodable
         }
 
         return $acl;
-
     }
 
     /**

--- a/src/Parse/ParsePush.php
+++ b/src/Parse/ParsePush.php
@@ -1,13 +1,17 @@
 <?php
+/**
+ * Class ParsePush | Parse/ParsePush.php
+ */
 
 namespace Parse;
 
 use Exception;
 
 /**
- * ParsePush - Handles sending push notifications with Parse.
+ * Class ParsePush - Handles sending push notifications with Parse.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParsePush
 {

--- a/src/Parse/ParsePushStatus.php
+++ b/src/Parse/ParsePushStatus.php
@@ -1,14 +1,23 @@
 <?php
+/**
+ * Class ParsePushStatus | Parse/ParsePushStatus.php
+ */
 
 namespace Parse;
 
 /**
- * ParsePushStatus - Representation of PushStatus for push notifications
+ * Class ParsePushStatus - Representation of PushStatus for push notifications
  *
  * @author Ben Friedman <ben@axolsoft.com>
+ * @package Parse
  */
 class ParsePushStatus extends ParseObject
 {
+    /**
+     * Parse Class name
+     *
+     * @var string
+     */
     public static $parseClassName = '_PushStatus';
 
     // possible push status values from parse server

--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -1,13 +1,17 @@
 <?php
+/**
+ * Class ParseQuery | Parse/ParseQuery.php
+ */
 
 namespace Parse;
 
 use Exception;
 
 /**
- * ParseQuery - Handles querying data from Parse.
+ * Class ParseQuery - Handles querying data from Parse.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseQuery
 {

--- a/src/Parse/ParseRelation.php
+++ b/src/Parse/ParseRelation.php
@@ -1,15 +1,18 @@
 <?php
+/**
+ * Class ParseRelation | Parse/ParseRelation.php
+ */
 
 namespace Parse;
 
-use Exception;
 use Parse\Internal\ParseRelationOperation;
 
 /**
- * ParseRelation - A class that is used to access all of the children of a many-to-many relationship. Each instance
+ * Class ParseRelation - A class that is used to access all of the children of a many-to-many relationship. Each instance
  * of ParseRelation is associated with a particular parent object and key.
  *
  * @author Mohamed Madbouli <mohamedmadbouli@fb.com>
+ * @package Parse
  */
 class ParseRelation
 {

--- a/src/Parse/ParseRelation.php
+++ b/src/Parse/ParseRelation.php
@@ -8,8 +8,8 @@ namespace Parse;
 use Parse\Internal\ParseRelationOperation;
 
 /**
- * Class ParseRelation - A class that is used to access all of the children of a many-to-many relationship. Each instance
- * of ParseRelation is associated with a particular parent object and key.
+ * Class ParseRelation - A class that is used to access all of the children of a many-to-many relationship.
+ * Each instance of ParseRelation is associated with a particular parent object and key.
  *
  * @author Mohamed Madbouli <mohamedmadbouli@fb.com>
  * @package Parse

--- a/src/Parse/ParseRole.php
+++ b/src/Parse/ParseRole.php
@@ -1,14 +1,23 @@
 <?php
+/**
+ * Class ParseRole | Parse/ParseRole.php
+ */
 
 namespace Parse;
 
 /**
- * ParseRole - Representation of an access Role.
+ * Class ParseRole - Representation of an access Role.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseRole extends ParseObject
 {
+    /**
+     * Parse Class name
+     *
+     * @var string
+     */
     public static $parseClassName = '_Role';
 
     /**

--- a/src/Parse/ParseSchema.php
+++ b/src/Parse/ParseSchema.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Class ParseSchema | Parse/ParseSchema.php
+ */
 
 namespace Parse;
 
@@ -6,24 +9,84 @@ use Exception;
 use InvalidArgumentException;
 
 /**
- * ParseSchema - Handles schemas data from Parse.
- * All the schemas methods needs use the master key of your application.
+ * Class ParseSchema - Handles schemas data from Parse.
+ * All the schemas methods need use of the master key for your application.
  *
- * @see https://parse.com/docs/rest/guide#schemas
+ * @see http://docs.parseplatform.org/rest/guide/#schema
  *
  * @author Júlio César Gonçalves de Oliveira <julio@pinguineras.com.br>
+ * @package Parse
  */
 class ParseSchema
 {
+    /**
+     * String data type
+     *
+     * @var string
+     */
     public static $STRING = 'String';
+
+    /**
+     * Number data type
+     *
+     * @var string
+     */
     public static $NUMBER = 'Number';
+
+    /**
+     * Boolean data type
+     *
+     * @var string
+     */
     public static $BOOLEAN = 'Boolean';
+
+    /**
+     * Date data type
+     *
+     * @var string
+     */
     public static $DATE = 'Date';
+
+    /**
+     * File data type
+     *
+     * @var string
+     */
     public static $FILE = 'File';
+
+    /**
+     * GeoPoint data type
+     *
+     * @var string
+     */
     public static $GEO_POINT = 'GeoPoint';
+
+    /**
+     * Array data type
+     *
+     * @var string
+     */
     public static $ARRAY = 'Array';
+
+    /**
+     * Object data type
+     *
+     * @var string
+     */
     public static $OBJECT = 'Object';
+
+    /**
+     * Pointer data type
+     *
+     * @var string
+     */
     public static $POINTER = 'Pointer';
+
+    /**
+     * Relation data type
+     *
+     * @var string
+     */
     public static $RELATION = 'Relation';
 
     /**
@@ -43,7 +106,7 @@ class ParseSchema
     /**
      * Force to use master key in Schema Methods.
      *
-     * @see https://parse.com/docs/rest/guide#schemas
+     * @see http://docs.parseplatform.org/rest/guide/#schema
      *
      * @var bool
      */

--- a/src/Parse/ParseSession.php
+++ b/src/Parse/ParseSession.php
@@ -1,16 +1,30 @@
 <?php
+/**
+ * Class ParseSession | Parse/ParseSession.php
+ */
 
 namespace Parse;
 
 /**
- * ParseSession - Representation of an expiring user session.
+ * Class ParseSession - Representation of an expiring user session.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseSession extends ParseObject
 {
+    /**
+     * Parse Class name
+     *
+     * @var string
+     */
     public static $parseClassName = '_Session';
 
+    /**
+     * Session token string
+     *
+     * @var null|string
+     */
     private $_sessionToken = null;
 
     /**

--- a/src/Parse/ParseSessionStorage.php
+++ b/src/Parse/ParseSessionStorage.php
@@ -1,11 +1,15 @@
 <?php
+/**
+ * Class ParseSessionStorage | Parse/ParseSessionStorage.php
+ */
 
 namespace Parse;
 
 /**
- * ParseSessionStorage - Uses PHP session support for persistent storage.
+ * Class ParseSessionStorage - Uses PHP session support for persistent storage.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseSessionStorage implements ParseStorageInterface
 {
@@ -16,6 +20,10 @@ class ParseSessionStorage implements ParseStorageInterface
      */
     private $storageKey = 'parseData';
 
+    /**
+     * ParseSessionStorage constructor.
+     * @throws ParseException
+     */
     public function __construct()
     {
         if (session_status() !== PHP_SESSION_ACTIVE) {
@@ -28,16 +36,38 @@ class ParseSessionStorage implements ParseStorageInterface
         }
     }
 
+    /**
+     * Sets a key-value pair in storage.
+     *
+     * @param string $key   The key to set
+     * @param mixed  $value The value to set
+     *
+     * @return void
+     */
     public function set($key, $value)
     {
         $_SESSION[$this->storageKey][$key] = $value;
     }
 
+    /**
+     * Remove a key from storage.
+     *
+     * @param string $key The key to remove.
+     *
+     * @return void
+     */
     public function remove($key)
     {
         unset($_SESSION[$this->storageKey][$key]);
     }
 
+    /**
+     * Gets the value for a key from storage.
+     *
+     * @param string $key The key to get the value for
+     *
+     * @return mixed
+     */
     public function get($key)
     {
         if (isset($_SESSION[$this->storageKey][$key])) {
@@ -47,22 +77,40 @@ class ParseSessionStorage implements ParseStorageInterface
         return;
     }
 
+    /**
+     * Clear all the values in storage.
+     *
+     * @return void
+     */
     public function clear()
     {
         $_SESSION[$this->storageKey] = [];
     }
 
+    /**
+     * Save the data, if necessary. Not implemented.
+     */
     public function save()
     {
         // No action required.    PHP handles persistence for $_SESSION.
         return;
     }
 
+    /**
+     * Get all keys in storage.
+     *
+     * @return array
+     */
     public function getKeys()
     {
         return array_keys($_SESSION[$this->storageKey]);
     }
 
+    /**
+     * Get all key-value pairs from storage.
+     *
+     * @return array
+     */
     public function getAll()
     {
         return $_SESSION[$this->storageKey];

--- a/src/Parse/ParseStorageInterface.php
+++ b/src/Parse/ParseStorageInterface.php
@@ -1,11 +1,15 @@
 <?php
+/**
+ * Class ParseStorageInterface | Parse/ParseStorageInterface.php
+ */
 
 namespace Parse;
 
 /**
- * ParseStorageInterface - Specifies an interface for implementing persistence.
+ * Class ParseStorageInterface - Specifies an interface for implementing persistence.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 interface ParseStorageInterface
 {

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -1,14 +1,23 @@
 <?php
+/**
+ * Class ParseUser | Parse/ParseUser.php
+ */
 
 namespace Parse;
 
 /**
- * ParseUser - Representation of a user object stored on Parse.
+ * Class ParseUser - Representation of a user object stored on Parse.
  *
  * @author Fosco Marotto <fjm@fb.com>
+ * @package Parse
  */
 class ParseUser extends ParseObject
 {
+    /**
+     * Parse Class name
+     *
+     * @var string
+     */
     public static $parseClassName = '_User';
 
     /**
@@ -395,8 +404,9 @@ class ParseUser extends ParseObject
     /**
      * Link the user with a service.
      *
-     * @param string $serviceName the name of the service
-     * @param array  $authData    the array of auth data for $serviceName
+     * @param string $serviceName   the name of the service
+     * @param array  $authData      the array of auth data for $serviceName
+     * @param bool $useMasterKey    Whether or not to use the master key, default is false
      *
      * @return ParseUser
      */
@@ -578,6 +588,9 @@ class ParseUser extends ParseObject
         ParseClient::_request('POST', 'requestPasswordReset', null, $json);
     }
 
+    /**
+     * Sets the current user to null. Used internally for testing purposes.
+     */
     public static function _clearCurrentUserVariable()
     {
         static::$currentUser = null;

--- a/tests/Parse/ParseSchemaTest.php
+++ b/tests/Parse/ParseSchemaTest.php
@@ -4,7 +4,7 @@
 /**
  * ParseSchema Tests.
  *
- * @see https://parse.com/docs/rest/guide#schemas
+ * @see http://docs.parseplatform.org/rest/guide/#schema
  *
  * @author Júlio César Gonçalves de Oliveira <julio@pinguineras.com.br>
  */


### PR DESCRIPTION
The php sdk has docs online at [parseplatform.org/parse-php-sdk/](http://parseplatform.org/parse-php-sdk/). But they are rather outdated from 2015. 

This updates the existing documentation and corrects any documentation errors for proper generation of updated docs. Once this is in place we can generate new docs using `npm run document`, which can be added to our [gh-pages](https://github.com/parse-community/parse-php-sdk/tree/gh-pages) branch.

_Note that_ generation of docs requires the [GraphViz](https://github.com/phpDocumentor/GraphViz) package to create a class inheritance diagram.