### PR TITLE
Remove Default API

### DIFF
--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -200,7 +200,6 @@ final class ParseClient
     public static function _clearServerURL()
     {
         self::$serverURL = null;
-
     }
 
     /**
@@ -605,7 +604,6 @@ final class ParseClient
                 'You must call ParseClient::setServerURL(\'https://your.parse-server.com\', \'/parse\') '.
                 ' before making any requests.'
             );
-
         }
 
         if (self::$mountPath === null) {
@@ -614,7 +612,6 @@ final class ParseClient
                 'You must call ParseClient::setServerURL(\'https://your.parse-server.com\', \'/parse\') '.
                 ' before making any requests.'
             );
-
         }
     }
 

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -24,14 +24,14 @@ final class ParseClient
      *
      * @var string
      */
-    private static $serverURL = 'https://api.parse.com/';
+    private static $serverURL = null;
 
     /**
      * The mount path for the current parse server
      *
      * @var string
      */
-    private static $mountPath = "1/";
+    private static $mountPath = null;
 
     /**
      * The application id.
@@ -191,6 +191,25 @@ final class ParseClient
             // root path should have no mount path
             self::$mountPath = "";
         }
+    }
+
+    /**
+     * Clears the existing server url.
+     * Used primarily for testing purposes.
+     */
+    public static function _clearServerURL()
+    {
+        self::$serverURL = null;
+
+    }
+
+    /**
+     * Clears the existing mount path.
+     * Used primarily for testing purposes.
+     */
+    public static function _clearMountPath()
+    {
+        self::$mountPath = null;
     }
 
     /**
@@ -408,6 +427,9 @@ final class ParseClient
             $httpClient->setCAFile(self::$caFile);
         }
 
+        // verify the server url and mount path have been set
+        self::assertServerInitialized();
+
         if ($appRequest) {
             // ** 'app' requests are not available in open source parse-server
             self::assertAppInitialized();
@@ -571,6 +593,32 @@ final class ParseClient
     }
 
     /**
+     * Asserts that the server and mount path have been initialized
+     *
+     * @throws Exception
+     */
+    private static function assertServerInitialized()
+    {
+        if (self::$serverURL === null) {
+            throw new Exception(
+                'Missing a valid server url. '.
+                'You must call ParseClient::setServerURL(\'https://your.parse-server.com\', \'/parse\') '.
+                ' before making any requests.'
+            );
+
+        }
+
+        if (self::$mountPath === null) {
+            throw new Exception(
+                'Missing a valid mount path. '.
+                'You must call ParseClient::setServerURL(\'https://your.parse-server.com\', \'/parse\') '.
+                ' before making any requests.'
+            );
+
+        }
+    }
+
+    /**
      * Asserts that the sdk has been initialized with a valid application id
      *
      * @throws Exception
@@ -579,7 +627,7 @@ final class ParseClient
     {
         if (self::$applicationId === null) {
             throw new Exception(
-                'You must call Parse::initialize() before making any requests.'
+                'You must call ParseClient::initialize() before making any requests.'
             );
         }
     }
@@ -593,7 +641,7 @@ final class ParseClient
     {
         if (self::$accountKey === null || empty(self::$accountKey)) {
             throw new Exception(
-                'You must call Parse::initialize(..., $accountKey) before making any app requests. '.
+                'You must call ParseClient::initialize(..., $accountKey) before making any app requests. '.
                 'Your account key must not be null or empty.'
             );
         }

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -533,7 +533,6 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
 
         ParseClient::_clearServerURL();
         (new ParseObject('TestingClass'))->save();
-
     }
 
     /**
@@ -550,7 +549,6 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
 
         ParseClient::_clearMountPath();
         (new ParseObject('TestingClass'))->save();
-
     }
 
     /**

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -47,7 +47,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(
             '\Exception',
-            'You must call Parse::initialize() before making any requests.'
+            'You must call ParseClient::initialize() before making any requests.'
         );
 
         ParseClient::initialize(
@@ -69,7 +69,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(
             '\Exception',
-            'You must call Parse::initialize(..., $accountKey) before making any app requests. '.
+            'You must call ParseClient::initialize(..., $accountKey) before making any app requests. '.
             'Your account key must not be null or empty.'
         );
 
@@ -517,6 +517,40 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
             '',
             null
         );
+    }
+
+    /**
+     * @group api-not-set
+     */
+    public function testURLNotSet()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'Missing a valid server url. '.
+            'You must call ParseClient::setServerURL(\'https://your.parse-server.com\', \'/parse\') '.
+            ' before making any requests.'
+        );
+
+        ParseClient::_clearServerURL();
+        (new ParseObject('TestingClass'))->save();
+
+    }
+
+    /**
+     * @group api-not-set
+     */
+    public function testMountPathNotSet()
+    {
+        $this->setExpectedException(
+            '\Exception',
+            'Missing a valid mount path. '.
+            'You must call ParseClient::setServerURL(\'https://your.parse-server.com\', \'/parse\') '.
+            ' before making any requests.'
+        );
+
+        ParseClient::_clearMountPath();
+        (new ParseObject('TestingClass'))->save();
+
     }
 
     /**


### PR DESCRIPTION
Currently the default url is `https://api.parse.com/` and the default mount path if `/1`. Given that **api.parse.com** is no longer active and will only respond to requests with the message `Parse.com has shutdown - https://parseplatform.github.io/` it is probably time to clear these defaults.

Additionally it would appear that there is no valid certificate for this api. Attempting to connect to the original service from this sdk will throw a `ParseException` containing the following message:
```
SSL certificate problem: Invalid certificate chain
```
This can be further verified through additional means (curl through the terminal, browser, etc).

This PR removes the default server url and mount path variables, and adds verification in `ParseClient::_request` that both the server url and the mount path have been initialized before proceeding. Tests have been added to account for both cases as well.

::EDIT::

This also contains a couple typo changes where `Parse::initialize` was stated in an exception message where it should be `ParseClient::initialize`. The relevant test cases were updated as well.