### PR TITLE
Full Text Search

### DIFF
--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -284,7 +284,7 @@ class ParseQuery
         return $this;
     }
 
-    /**
+     /**
      * Adds a constraint for finding string values that contain a provided
      * string. This may be slow for large datasets.
      *
@@ -296,6 +296,26 @@ class ParseQuery
     public function contains($key, $value)
     {
         $this->addCondition($key, '$regex', $this->quote($value));
+
+        return $this;
+    }
+
+    /**
+     * Adds a constraint for finding string values that contain a provided
+     * string using Full Text Search
+     *
+     * @param string $key   The key to check.
+     * @param mixed  $value The substring that the value must contain.
+     *
+     * @return ParseQuery Returns this query, so you can chain this call.
+     */
+    public function fullText($key, $value)
+    {
+        $this->addCondition(
+            $key,
+            '$text',
+            ['$search' => ['$term' => $value]]
+        );
 
         return $this;
     }

--- a/tests/Parse/ParseQueryFullTextTest.php
+++ b/tests/Parse/ParseQueryFullTextTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Parse\Test;
+
+use Parse\ParseException;
+use Parse\ParseObject;
+use Parse\ParseQuery;
+
+class ParseQueryFullTextTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Helper::setUp();
+    }
+
+    public function setUp()
+    {
+        Helper::clearClass('TestObject');
+    }
+
+    public function tearDown()
+    {
+        Helper::tearDown();
+    }
+
+    /**
+     * This function used as a helper function in test functions to save objects.
+     */
+    public function provideTestObjects()
+    {
+        $subjects = [
+            'coffee',
+            'Coffee Shopping',
+            'Baking a cake',
+            'baking',
+            'Café Con Leche',
+            'Сырники',
+            'coffee and cream',
+            'Cafe con Leche'
+        ];
+
+        $allObjects = [];
+        for ($i = 0; $i < count($subjects); ++$i) {
+            $obj = new ParseObject('TestObject');
+            $obj->set('subject', $subjects[$i]);
+            $allObjects[] = $obj;
+        }
+        ParseObject::saveAll($allObjects);
+    }
+
+    public function testFullTextQuery()
+    {
+        $this->provideTestObjects();
+        $query = new ParseQuery('TestObject');
+        $query->fullText('subject', 'coffee');
+        $results = $query->find();
+        $this->assertEquals(
+            3,
+            count($results),
+            'Did not return correct objects.'
+        );
+    }
+
+    public function testFullTextSort()
+    {
+        $this->provideTestObjects();
+        $query = new ParseQuery('TestObject');
+        $query->fullText('subject', 'coffee');
+        $query->ascending('$score');
+        $query->select('$score');
+        $results = $query->find();
+        $this->assertEquals(
+            3,
+            count($results),
+            'Did not return correct number of objects.'
+        );
+        $this->assertEquals(1, $results[0]->get('score'));
+        $this->assertEquals(0.75, $results[1]->get('score'));
+        $this->assertEquals(0.75, $results[2]->get('score'));
+    }
+}


### PR DESCRIPTION
https://github.com/parse-community/parse-server/pull/3904

I've added full text search and sort to ParseQuery.

I didn't add support for $language, $caseSensitive, $diraticSensitive just $term.

To run the tests you need to create a text index in mongo. Because of this fact this PR will fail on travis

`mongo localhost:27017/test`

`db.TestObject.createIndex( { subject: "text" } )`

Let me know your thoughts on this.