### PR TITLE
Adds specific error codes to certain ParseExceptions

### DIFF
--- a/src/Parse/Internal/ParseRelationOperation.php
+++ b/src/Parse/Internal/ParseRelationOperation.php
@@ -83,7 +83,7 @@ class ParseRelationOperation implements FieldOperation
                 $this->targetClassName = $object->getClassName();
             }
             if ($this->targetClassName != $object->getClassName()) {
-                throw new Exception('All objects in a relation must be of the same class.');
+                throw new Exception('All objects in a relation must be of the same class.', 103);
             }
         }
     }
@@ -155,7 +155,8 @@ class ParseRelationOperation implements FieldOperation
                 throw new Exception(
                     'Related object object must be of class '
                     .$this->targetClassName.', but '.$oldValue->getTargetClass()
-                    .' was passed in.'
+                    .' was passed in.',
+                    103
                 );
             }
 
@@ -187,7 +188,8 @@ class ParseRelationOperation implements FieldOperation
                 throw new Exception(
                     'Related object object must be of class '
                     .$this->targetClassName.', but '.$previous->targetClassName
-                    .' was passed in.'
+                    .' was passed in.',
+                    103
                 );
             }
             $newRelationToAdd = self::convertToOneDimensionalArray(

--- a/src/Parse/ParseACL.php
+++ b/src/Parse/ParseACL.php
@@ -169,7 +169,8 @@ class ParseACL implements Encodable
         }
         if (!is_string($userId)) {
             throw new ParseException(
-                'Invalid target for access control.'
+                'Invalid target for access control.',
+                104
             );
         }
         if (!isset($this->permissionsById[$userId])) {

--- a/src/Parse/ParseACL.php
+++ b/src/Parse/ParseACL.php
@@ -95,7 +95,7 @@ class ParseACL implements Encodable
         $acl = new self();
         foreach ($data as $id => $permissions) {
             if (!is_string($id)) {
-                throw new Exception('Tried to create an ACL with an invalid userId.');
+                throw new Exception('Tried to create an ACL with an invalid userId.', 104);
             }
             foreach ($permissions as $accessType => $value) {
                 if ($accessType !== 'read' && $accessType !== 'write') {
@@ -220,7 +220,7 @@ class ParseACL implements Encodable
     public function setReadAccess($userId, $allowed)
     {
         if (!$userId) {
-            throw new Exception('cannot setReadAccess for null userId');
+            throw new Exception('cannot setReadAccess for null userId', 104);
         }
         $this->setAccess('read', $userId, $allowed);
     }
@@ -240,7 +240,7 @@ class ParseACL implements Encodable
     public function getReadAccess($userId)
     {
         if (!$userId) {
-            throw new Exception('cannot getReadAccess for null userId');
+            throw new Exception('cannot getReadAccess for null userId', 104);
         }
 
         return $this->getAccess('read', $userId);
@@ -257,7 +257,7 @@ class ParseACL implements Encodable
     public function setWriteAccess($userId, $allowed)
     {
         if (!$userId) {
-            throw new Exception('cannot setWriteAccess for null userId');
+            throw new Exception('cannot setWriteAccess for null userId', 104);
         }
         $this->setAccess('write', $userId, $allowed);
     }
@@ -277,7 +277,7 @@ class ParseACL implements Encodable
     public function getWriteAccess($userId)
     {
         if (!$userId) {
-            throw new Exception('cannot getWriteAccess for null userId');
+            throw new Exception('cannot getWriteAccess for null userId', 104);
         }
 
         return $this->getAccess('write', $userId);
@@ -334,7 +334,7 @@ class ParseACL implements Encodable
     public function setUserReadAccess($user, $allowed)
     {
         if (!$user->getObjectId()) {
-            throw new Exception('cannot setReadAccess for a user with null id');
+            throw new Exception('cannot setReadAccess for a user with null id', 104);
         }
         $this->setReadAccess($user->getObjectId(), $allowed);
     }
@@ -354,7 +354,7 @@ class ParseACL implements Encodable
     public function getUserReadAccess($user)
     {
         if (!$user->getObjectId()) {
-            throw new Exception('cannot getReadAccess for a user with null id');
+            throw new Exception('cannot getReadAccess for a user with null id', 104);
         }
 
         return $this->getReadAccess($user->getObjectId());
@@ -371,7 +371,7 @@ class ParseACL implements Encodable
     public function setUserWriteAccess($user, $allowed)
     {
         if (!$user->getObjectId()) {
-            throw new Exception('cannot setWriteAccess for a user with null id');
+            throw new Exception('cannot setWriteAccess for a user with null id', 104);
         }
         $this->setWriteAccess($user->getObjectId(), $allowed);
     }
@@ -391,7 +391,7 @@ class ParseACL implements Encodable
     public function getUserWriteAccess($user)
     {
         if (!$user->getObjectId()) {
-            throw new Exception('cannot getWriteAccess for a user with null id');
+            throw new Exception('cannot getWriteAccess for a user with null id', 104);
         }
 
         return $this->getWriteAccess($user->getObjectId());
@@ -460,7 +460,8 @@ class ParseACL implements Encodable
     {
         if (!$role->getObjectId()) {
             throw new Exception(
-                'Roles must be saved to the server before they can be used in an ACL.'
+                'Roles must be saved to the server before they can be used in an ACL.',
+                104
             );
         }
     }

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -624,7 +624,8 @@ final class ParseClient
     {
         if (self::$applicationId === null) {
             throw new Exception(
-                'You must call ParseClient::initialize() before making any requests.'
+                'You must call ParseClient::initialize() before making any requests.',
+                109
             );
         }
     }
@@ -639,7 +640,8 @@ final class ParseClient
         if (self::$accountKey === null || empty(self::$accountKey)) {
             throw new Exception(
                 'You must call ParseClient::initialize(..., $accountKey) before making any app requests. '.
-                'Your account key must not be null or empty.'
+                'Your account key must not be null or empty.',
+                109
             );
         }
     }

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -56,7 +56,8 @@ class ParseFile implements Encodable
             return $this->data;
         }
         if (!$this->url) {
-            throw new ParseException('Cannot retrieve data for unsaved ParseFile.');
+            throw new ParseException('Cannot retrieve data for unsaved ParseFile.',
+                151);
         }
         $this->data = $this->download();
 
@@ -93,7 +94,8 @@ class ParseFile implements Encodable
     public function delete($useMasterKey = true)
     {
         if (!$this->url) {
-            throw new ParseException('Cannot delete file that has not been saved.');
+            throw new ParseException('Cannot delete file that has not been saved.',
+                151);
         }
 
         ParseClient::_request(

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -56,8 +56,7 @@ class ParseFile implements Encodable
             return $this->data;
         }
         if (!$this->url) {
-            throw new ParseException('Cannot retrieve data for unsaved ParseFile.',
-                151);
+            throw new ParseException('Cannot retrieve data for unsaved ParseFile.', 151);
         }
         $this->data = $this->download();
 
@@ -94,8 +93,7 @@ class ParseFile implements Encodable
     public function delete($useMasterKey = true)
     {
         if (!$this->url) {
-            throw new ParseException('Cannot delete file that has not been saved.',
-                151);
+            throw new ParseException('Cannot delete file that has not been saved.', 151);
         }
 
         ParseClient::_request(

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -576,9 +576,9 @@ class ParseObject implements Encodable
         for ($i = 0; $i < $count; ++$i) {
             $obj = $objects[$i];
             if ($obj->getClassName() !== $className) {
-                throw new ParseException('All objects should be of the same class.');
+                throw new ParseException('All objects should be of the same class.', 103);
             } elseif (!$obj->getObjectId()) {
-                throw new ParseException('All objects must have an ID.');
+                throw new ParseException('All objects must have an ID.', 104);
             }
             array_push($objectIds, $obj->getObjectId());
         }
@@ -604,7 +604,7 @@ class ParseObject implements Encodable
         for ($i = 0; $i < $count; ++$i) {
             $obj = $objects[$i];
             if (!isset($fetchedObjectsById[$obj->getObjectId()])) {
-                throw new ParseException('All objects must exist on the server.');
+                throw new ParseException('All objects must exist on the server.', 101);
             }
             $obj->mergeFromObject($fetchedObjectsById[$obj->getObjectId()]);
         }

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -110,7 +110,8 @@ class ParseObject implements Encodable
         if (empty(self::$registeredSubclasses)) {
             throw new Exception(
                 'You must initialize the ParseClient using ParseClient::initialize '.
-                'and your Parse API keys before you can begin working with Objects.'
+                'and your Parse API keys before you can begin working with Objects.',
+                109
             );
         }
         $subclass = static::getSubclass();
@@ -163,7 +164,7 @@ class ParseObject implements Encodable
         ) {
             $this->set($key, $value);
         } else {
-            throw new Exception('Protected field could not be set.');
+            throw new Exception('Protected field could not be set.', 139);
         }
     }
 
@@ -1279,7 +1280,7 @@ class ParseObject implements Encodable
     public function _toPointer()
     {
         if (!$this->objectId) {
-            throw new Exception("Can't serialize an unsaved Parse.Object");
+            throw new Exception("Can't serialize an unsaved ParseObject", 104);
         }
 
         return [

--- a/src/Parse/ParsePush.php
+++ b/src/Parse/ParsePush.php
@@ -40,7 +40,8 @@ class ParsePush
             && isset($data['expiration_interval'])
         ) {
             throw new Exception(
-                'Both expiration_time and expiration_interval can\'t be set.'
+                'Both expiration_time and expiration_interval can\'t be set.',
+                138
             );
         }
         if (isset($data['where'])) {
@@ -54,7 +55,8 @@ class ParsePush
                 }
             } else {
                 throw new Exception(
-                    'Where parameter for Parse Push must be of type ParseQuery'
+                    'Where parameter for Parse Push must be of type ParseQuery',
+                    111
                 );
             }
         }

--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -845,7 +845,7 @@ class ParseQuery
                 $className = $queryObjects[$i]->className;
             }
             if ($className != $queryObjects[$i]->className) {
-                throw new Exception('All queries must be for the same class');
+                throw new Exception('All queries must be for the same class', 103);
             }
         }
         $query = new self($className);

--- a/src/Parse/ParseRole.php
+++ b/src/Parse/ParseRole.php
@@ -105,14 +105,10 @@ class ParseRole extends ParseObject
     public function save($useMasterKey = false)
     {
         if (!$this->getACL()) {
-            throw new ParseException(
-                'Roles must have an ACL.', 123
-            );
+            throw new ParseException('Roles must have an ACL.', 123);
         }
         if (!$this->getName() || !is_string($this->getName())) {
-            throw new ParseException(
-                'Roles must have a name.', 139
-            );
+            throw new ParseException('Roles must have a name.', 139);
         }
         if ($this->getObjectId() === null) {
             // Not yet saved, verify this name is not taken
@@ -120,8 +116,7 @@ class ParseRole extends ParseObject
             $query = new ParseQuery('_Role');
             $query->equalTo('name', $this->getName());
             if ($query->count(true) > 0) {
-                throw new ParseException("Cannot add duplicate role name of '{$this->getName()}'",
-                    137);
+                throw new ParseException("Cannot add duplicate role name of '{$this->getName()}'", 137);
             }
         }
 

--- a/src/Parse/ParseRole.php
+++ b/src/Parse/ParseRole.php
@@ -57,15 +57,10 @@ class ParseRole extends ParseObject
     public function setName($name)
     {
         if ($this->getObjectId()) {
-            throw new ParseException(
-                "A role's name can only be set before it has been saved.",
-                139
-            );
+            throw new ParseException("A role's name can only be set before it has been saved.");
         }
         if (!is_string($name)) {
-            throw new ParseException(
-                "A role's name must be a string."
-            );
+            throw new ParseException("A role's name must be a string.", 139);
         }
 
         return $this->set('name', $name);

--- a/src/Parse/ParseRole.php
+++ b/src/Parse/ParseRole.php
@@ -58,7 +58,8 @@ class ParseRole extends ParseObject
     {
         if ($this->getObjectId()) {
             throw new ParseException(
-                "A role's name can only be set before it has been saved."
+                "A role's name can only be set before it has been saved.",
+                139
             );
         }
         if (!is_string($name)) {
@@ -105,12 +106,12 @@ class ParseRole extends ParseObject
     {
         if (!$this->getACL()) {
             throw new ParseException(
-                'Roles must have an ACL.'
+                'Roles must have an ACL.', 123
             );
         }
         if (!$this->getName() || !is_string($this->getName())) {
             throw new ParseException(
-                'Roles must have a name.'
+                'Roles must have a name.', 139
             );
         }
         if ($this->getObjectId() === null) {
@@ -119,7 +120,8 @@ class ParseRole extends ParseObject
             $query = new ParseQuery('_Role');
             $query->equalTo('name', $this->getName());
             if ($query->count(true) > 0) {
-                throw new ParseException("Cannot add duplicate role name of '{$this->getName()}'");
+                throw new ParseException("Cannot add duplicate role name of '{$this->getName()}'",
+                    137);
             }
         }
 

--- a/src/Parse/ParseSchema.php
+++ b/src/Parse/ParseSchema.php
@@ -303,7 +303,7 @@ class ParseSchema
     public function addField($fieldName = null, $fieldType = 'String')
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
         if (!$fieldType) {
             throw new Exception('Type name may not be null.');
@@ -330,7 +330,7 @@ class ParseSchema
     public function addString($fieldName = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         $this->fields[$fieldName] = [
@@ -352,7 +352,7 @@ class ParseSchema
     public function addNumber($fieldName = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         $this->fields[$fieldName] = [
@@ -374,7 +374,7 @@ class ParseSchema
     public function addBoolean($fieldName = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         $this->fields[$fieldName] = [
@@ -396,7 +396,7 @@ class ParseSchema
     public function addDate($fieldName = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         $this->fields[$fieldName] = [
@@ -418,7 +418,7 @@ class ParseSchema
     public function addFile($fieldName = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         $this->fields[$fieldName] = [
@@ -440,7 +440,7 @@ class ParseSchema
     public function addGeoPoint($fieldName = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         $this->fields[$fieldName] = [
@@ -462,7 +462,7 @@ class ParseSchema
     public function addArray($fieldName = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         $this->fields[$fieldName] = [
@@ -484,7 +484,7 @@ class ParseSchema
     public function addObject($fieldName = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         $this->fields[$fieldName] = [
@@ -507,11 +507,11 @@ class ParseSchema
     public function addPointer($fieldName = null, $targetClass = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         if (!$targetClass) {
-            throw new Exception('You need set the targetClass of the Pointer.');
+            throw new Exception('You need to set the targetClass of the Pointer.', 103);
         }
 
         $this->fields[$fieldName] = [
@@ -535,11 +535,11 @@ class ParseSchema
     public function addRelation($fieldName = null, $targetClass = null)
     {
         if (!$fieldName) {
-            throw new Exception('field name may not be null.');
+            throw new Exception('field name may not be null.', 105);
         }
 
         if (!$targetClass) {
-            throw new Exception('You need set the targetClass of the Relation.');
+            throw new Exception('You need to set the targetClass of the Relation.', 103);
         }
 
         $this->fields[$fieldName] = [
@@ -574,7 +574,7 @@ class ParseSchema
     public function assertClassName()
     {
         if ($this->className === null) {
-            throw new Exception('You must set a Class Name before make any request.');
+            throw new Exception('You must set a Class Name before making any request.', 103);
         }
     }
 

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -102,16 +102,18 @@ class ParseUser extends ParseObject
     public function signUp()
     {
         if (!$this->get('username')) {
-            throw new ParseException('Cannot sign up user with an empty name');
+            throw new ParseException('Cannot sign up user with an empty name', 200);
         }
         if (!$this->get('password')) {
             throw new ParseException(
-                'Cannot sign up user with an empty password.'
+                'Cannot sign up user with an empty password.',
+                201
             );
         }
         if ($this->getObjectId()) {
             throw new ParseException(
-                'Cannot sign up an already existing user.'
+                'Cannot sign up an already existing user.',
+                208
             );
         }
         parent::save();
@@ -131,11 +133,12 @@ class ParseUser extends ParseObject
     public static function logIn($username, $password)
     {
         if (!$username) {
-            throw new ParseException('Cannot log in user with an empty name');
+            throw new ParseException('Cannot log in user with an empty name', 200);
         }
         if (!$password) {
             throw new ParseException(
-                'Cannot log in user with an empty password.'
+                'Cannot log in user with an empty password.',
+                201
             );
         }
         $data = ['username' => $username, 'password' => $password];
@@ -162,11 +165,13 @@ class ParseUser extends ParseObject
     public static function logInWithFacebook($id, $access_token, $expiration_date = null)
     {
         if (!$id) {
-            throw new ParseException('Cannot log in Facebook user without an id.');
+            throw new ParseException('Cannot log in Facebook user without an id.',
+                250);
         }
         if (!$access_token) {
             throw new ParseException(
-                'Cannot log in Facebook user without an access token.'
+                'Cannot log in Facebook user without an access token.',
+                251
             );
         }
         if (!$expiration_date) {
@@ -207,26 +212,31 @@ class ParseUser extends ParseObject
     ) {
 
         if (!$id) {
-            throw new ParseException('Cannot log in Twitter user without an id.');
+            throw new ParseException('Cannot log in Twitter user without an id.',
+                250);
         }
         if (!$screen_name) {
             throw new ParseException(
-                'Cannot log in Twitter user without Twitter screen name.'
+                'Cannot log in Twitter user without Twitter screen name.',
+                253
             );
         }
         if (!$consumer_key) {
             throw new ParseException(
-                'Cannot log in Twitter user without a consumer key.'
+                'Cannot log in Twitter user without a consumer key.',
+                253
             );
         }
         if (!$auth_token) {
             throw new ParseException(
-                'Cannot log in Twitter user without an auth token.'
+                'Cannot log in Twitter user without an auth token.',
+                253
             );
         }
         if (!$auth_token_secret) {
             throw new ParseException(
-                'Cannot log in Twitter user without an auth token secret.'
+                'Cannot log in Twitter user without an auth token secret.',
+                253
             );
         }
         $authData = [
@@ -313,15 +323,18 @@ class ParseUser extends ParseObject
 
         if (!$this->getObjectId()) {
             throw new ParseException(
-                'Cannot link an unsaved user, use ParseUser::logInWithFacebook'
+                'Cannot link an unsaved user, use ParseUser::logInWithFacebook',
+                252
             );
         }
         if (!$id) {
-            throw new ParseException('Cannot link Facebook user without an id.');
+            throw new ParseException('Cannot link Facebook user without an id.',
+                250);
         }
         if (!$access_token) {
             throw new ParseException(
-                'Cannot link Facebook user without an access token.'
+                'Cannot link Facebook user without an access token.',
+                253
             );
         }
         if (!$expiration_date) {
@@ -364,29 +377,35 @@ class ParseUser extends ParseObject
     ) {
 
         if (!$this->getObjectId()) {
-            throw new ParseException('Cannot link an unsaved user, use ParseUser::logInWithTwitter');
+            throw new ParseException('Cannot link an unsaved user, use ParseUser::logInWithTwitter',
+                252);
         }
         if (!$id) {
-            throw new ParseException('Cannot link Twitter user without an id.');
+            throw new ParseException('Cannot link Twitter user without an id.',
+                250);
         }
         if (!$screen_name) {
             throw new ParseException(
-                'Cannot link Twitter user without Twitter screen name.'
+                'Cannot link Twitter user without Twitter screen name.',
+                253
             );
         }
         if (!$consumer_key) {
             throw new ParseException(
-                'Cannot link Twitter user without a consumer key.'
+                'Cannot link Twitter user without a consumer key.',
+                253
             );
         }
         if (!$auth_token) {
             throw new ParseException(
-                'Cannot link Twitter user without an auth token.'
+                'Cannot link Twitter user without an auth token.',
+                253
             );
         }
         if (!$auth_token_secret) {
             throw new ParseException(
-                'Cannot link Twitter user without an auth token secret.'
+                'Cannot link Twitter user without an auth token secret.',
+                253
             );
         }
         $authData = [
@@ -570,7 +589,8 @@ class ParseUser extends ParseObject
             parent::save($useMasterKey);
         } else {
             throw new ParseException(
-                'You must call signUp to create a new User.'
+                'You must call signUp to create a new User.',
+                207
             );
         }
     }

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -102,7 +102,10 @@ class ParseUser extends ParseObject
     public function signUp()
     {
         if (!$this->get('username')) {
-            throw new ParseException('Cannot sign up user with an empty name', 200);
+            throw new ParseException(
+                'Cannot sign up user with an empty name',
+                200
+            );
         }
         if (!$this->get('password')) {
             throw new ParseException(
@@ -133,7 +136,10 @@ class ParseUser extends ParseObject
     public static function logIn($username, $password)
     {
         if (!$username) {
-            throw new ParseException('Cannot log in user with an empty name', 200);
+            throw new ParseException(
+                'Cannot log in user with an empty name',
+                200
+            );
         }
         if (!$password) {
             throw new ParseException(
@@ -165,8 +171,10 @@ class ParseUser extends ParseObject
     public static function logInWithFacebook($id, $access_token, $expiration_date = null)
     {
         if (!$id) {
-            throw new ParseException('Cannot log in Facebook user without an id.',
-                250);
+            throw new ParseException(
+                'Cannot log in Facebook user without an id.',
+                250
+            );
         }
         if (!$access_token) {
             throw new ParseException(
@@ -212,8 +220,10 @@ class ParseUser extends ParseObject
     ) {
 
         if (!$id) {
-            throw new ParseException('Cannot log in Twitter user without an id.',
-                250);
+            throw new ParseException(
+                'Cannot log in Twitter user without an id.',
+                250
+            );
         }
         if (!$screen_name) {
             throw new ParseException(
@@ -328,8 +338,10 @@ class ParseUser extends ParseObject
             );
         }
         if (!$id) {
-            throw new ParseException('Cannot link Facebook user without an id.',
-                250);
+            throw new ParseException(
+                'Cannot link Facebook user without an id.',
+                250
+            );
         }
         if (!$access_token) {
             throw new ParseException(
@@ -377,37 +389,24 @@ class ParseUser extends ParseObject
     ) {
 
         if (!$this->getObjectId()) {
-            throw new ParseException('Cannot link an unsaved user, use ParseUser::logInWithTwitter',
-                252);
+            throw new ParseException('Cannot link an unsaved user, use ParseUser::logInWithTwitter', 252);
         }
         if (!$id) {
-            throw new ParseException('Cannot link Twitter user without an id.',
-                250);
+            throw new ParseException('Cannot link Twitter user without an id.', 250);
         }
         if (!$screen_name) {
-            throw new ParseException(
-                'Cannot link Twitter user without Twitter screen name.',
-                253
-            );
+            throw new ParseException('Cannot link Twitter user without Twitter screen name.', 253);
         }
         if (!$consumer_key) {
-            throw new ParseException(
-                'Cannot link Twitter user without a consumer key.',
-                253
-            );
+            throw new ParseException('Cannot link Twitter user without a consumer key.', 253);
         }
         if (!$auth_token) {
-            throw new ParseException(
-                'Cannot link Twitter user without an auth token.',
-                253
-            );
+            throw new ParseException('Cannot link Twitter user without an auth token.', 253);
         }
         if (!$auth_token_secret) {
-            throw new ParseException(
-                'Cannot link Twitter user without an auth token secret.',
-                253
-            );
+            throw new ParseException('Cannot link Twitter user without an auth token secret.', 253);
         }
+
         $authData = [
             'id'                => $id,
             'screen_name'       => $screen_name,

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -228,7 +228,7 @@ class ParseUser extends ParseObject
         if (!$screen_name) {
             throw new ParseException(
                 'Cannot log in Twitter user without Twitter screen name.',
-                253
+                251
             );
         }
         if (!$consumer_key) {
@@ -334,7 +334,7 @@ class ParseUser extends ParseObject
         if (!$this->getObjectId()) {
             throw new ParseException(
                 'Cannot link an unsaved user, use ParseUser::logInWithFacebook',
-                252
+                104
             );
         }
         if (!$id) {
@@ -346,7 +346,7 @@ class ParseUser extends ParseObject
         if (!$access_token) {
             throw new ParseException(
                 'Cannot link Facebook user without an access token.',
-                253
+                251
             );
         }
         if (!$expiration_date) {
@@ -389,13 +389,13 @@ class ParseUser extends ParseObject
     ) {
 
         if (!$this->getObjectId()) {
-            throw new ParseException('Cannot link an unsaved user, use ParseUser::logInWithTwitter', 252);
+            throw new ParseException('Cannot link an unsaved user, use ParseUser::logInWithTwitter', 104);
         }
         if (!$id) {
             throw new ParseException('Cannot link Twitter user without an id.', 250);
         }
         if (!$screen_name) {
-            throw new ParseException('Cannot link Twitter user without Twitter screen name.', 253);
+            throw new ParseException('Cannot link Twitter user without Twitter screen name.', 251);
         }
         if (!$consumer_key) {
             throw new ParseException('Cannot link Twitter user without a consumer key.', 253);

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -1418,7 +1418,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(
             '\Exception',
-            "Can't serialize an unsaved Parse.Object"
+            "Can't serialize an unsaved ParseObject"
         );
         (new ParseObject('TestClass'))->_toPointer();
     }

--- a/tests/Parse/ParseSchemaTest.php
+++ b/tests/Parse/ParseSchemaTest.php
@@ -212,7 +212,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
     public function testAssertClassName()
     {
         $schema = new ParseSchema();
-        $this->setExpectedException('\Exception', 'You must set a Class Name before make any request.');
+        $this->setExpectedException('\Exception', 'You must set a Class Name before making any request.');
         $schema->assertClassName();
     }
 
@@ -296,14 +296,14 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
     public function testPointerTargetClassException()
     {
         $schema = self::$schema;
-        $this->setExpectedException('\Exception', 'You need set the targetClass of the Pointer.');
+        $this->setExpectedException('\Exception', 'You need to set the targetClass of the Pointer.');
         $schema->addPointer('field', null);
     }
 
     public function testRelationTargetClassException()
     {
         $schema = self::$schema;
-        $this->setExpectedException('\Exception', 'You need set the targetClass of the Relation.');
+        $this->setExpectedException('\Exception', 'You need to set the targetClass of the Relation.');
         $schema->addRelation('field', null);
     }
 


### PR DESCRIPTION
As mentioned in #180 some time ago, some of the exceptions thrown from this SDK should be setting errors codes as documented in the [guide](http://docs.parseplatform.org/php/guide/#error-codes). Not all the exceptions can associate to codes that would make sense, so I have only modified those that are relevant.

If there are any other exceptions that anyone thinks could still use a relevant code go ahead and comment on it. Same for if there are any concerns with some of the exception/code pairings that I've made.

This PR makes no changes to the existing functionality and no new tests were added, just further details for exception handling.