### PR TITLE
Pages autodeploy and phpdoc style enforcing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - npm run lint
 script:
   - npm run test:coverage
-  - npm run document-check
+  - npm run document-check && if [[ `cat \"output/checkstyle.xml\" | grep \"<error \"` != \"\" ]]; then exit 1; fi
 before_deploy:
   - npm run document
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - npm run lint
 script:
   - npm run test:coverage
-  - npm run document-check && if [[ `cat \"output/checkstyle.xml\" | grep \"<error \"` != \"\" ]]; then exit 1; fi
+  - npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
 before_deploy:
   - npm run document
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,16 @@ before_script:
   - sleep 3
   - npm run lint
 script:
-    - npm run test:coverage
-
+  - npm run test:coverage
+  - npm run document-check
+before_deploy:
+  - npm run document
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  local_dir: output
+  on:
+    branch: master
 after_success:
-    - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_deploy:
 deploy:
   provider: pages
   skip_cleanup: true
-  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  github_token: $GITHUB_TOKEN
   local_dir: output
   on:
     branch: master

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint:fix": "./vendor/bin/phpcbf --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "start" : "./node_modules/parse-server-test/run-server",
     "stop"  : "./node_modules/parse-server-test/stop-server",
+    "document-check"  : "./vendor/bin/phpdoc -d ./src/ --template=checkstyle && if [[ `cat output/checkstyle.xml | grep \"<error\"` != \"\" ]]; then exit 1; fi",
     "document" : "./vendor/bin/phpdoc -d ./src/ --title 'Parse PHP SDK API Reference' --template='responsive-twig'"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint:fix": "./vendor/bin/phpcbf --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "start" : "./node_modules/parse-server-test/run-server",
     "stop"  : "./node_modules/parse-server-test/stop-server",
-    "document-check"  : "./vendor/bin/phpdoc -d ./src/ --template=checkstyle && if [[ `cat output/checkstyle.xml | grep \"<error\"` != \"\" ]]; then exit 1; fi",
+    "document-check"  : "./vendor/bin/phpdoc -d ./src/ --template=checkstyle && if [[ `cat \"output/checkstyle.xml\" | grep \"<error \"` != \"\" ]]; then exit 1; fi",
     "document" : "./vendor/bin/phpdoc -d ./src/ --title 'Parse PHP SDK API Reference' --template='responsive-twig'"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint:fix": "./vendor/bin/phpcbf --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "start" : "./node_modules/parse-server-test/run-server",
     "stop"  : "./node_modules/parse-server-test/stop-server",
-    "document-check"  : "./vendor/bin/phpdoc -d ./src/ --template=checkstyle && if [[ `cat \"output/checkstyle.xml\" | grep \"<error \"` != \"\" ]]; then exit 1; fi",
+    "document-check"  : "./vendor/bin/phpdoc -d ./src/ --template=checkstyle",
     "document" : "./vendor/bin/phpdoc -d ./src/ --title 'Parse PHP SDK API Reference' --template='responsive-twig'"
   },
   "repository": {

--- a/src/Parse/ParseACL.php
+++ b/src/Parse/ParseACL.php
@@ -8,6 +8,17 @@ namespace Parse;
 use Exception;
 use Parse\Internal\Encodable;
 
+/**
+ * Class ParseACL - is used to control which users can access or modify a particular
+ * object. Each ParseObject can have its own ParseACL. You can grant read and
+ * write permissions separately to specific users, to groups of users that
+ * belong to roles, or you can grant permissions to "the public" so that, for
+ * example, any user could read a particular object but only a particular set
+ * of users could write to that object.
+ *
+ * @author Mohamed Madbouli <mohamedmadbouli@fb.com>
+ * @package Parse
+ */
 class ParseACL implements Encodable
 {
     const PUBLIC_KEY = '*';

--- a/src/Parse/ParseACL.php
+++ b/src/Parse/ParseACL.php
@@ -8,7 +8,6 @@ namespace Parse;
 use Exception;
 use Parse\Internal\Encodable;
 
-
 class ParseACL implements Encodable
 {
     const PUBLIC_KEY = '*';

--- a/src/Parse/ParseACL.php
+++ b/src/Parse/ParseACL.php
@@ -8,17 +8,7 @@ namespace Parse;
 use Exception;
 use Parse\Internal\Encodable;
 
-/**
- * Class ParseACL - is used to control which users can access or modify a particular
- * object. Each ParseObject can have its own ParseACL. You can grant read and
- * write permissions separately to specific users, to groups of users that
- * belong to roles, or you can grant permissions to "the public" so that, for
- * example, any user could read a particular object but only a particular set
- * of users could write to that object.
- *
- * @author Mohamed Madbouli <mohamedmadbouli@fb.com>
- * @package Parse
- */
+
 class ParseACL implements Encodable
 {
     const PUBLIC_KEY = '*';


### PR DESCRIPTION
This adds `document-check` to **package.json** to allow enforcement of phpdoc standards. This also modifies **.travis.yml** to run this check after the tests are done. Via `document-check` **checkstyle.xml** is checked for any errors, and if found will exit with code `1`.

This also adds a deployment phase to automatically setup our `gh-pages` on each release, which must currently be done by hand. By enforcing `document-check` in the existing test-suite we can be sure that our generated api reference is 💯 % and always up to date for each release.

#### This will require a github token in order to function.
If there's an existing one we'll be good, right now it's just stubbed out from the docs. But if not we have the option of either passing it directly in this file or setting it up as an [environment var](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings). Either works, assuming this gets a go ahead.

There's a few other parameters that can be specified when [deploying to pages](https://docs.travis-ci.com/user/deployment/pages/), we could pass an email, name, etc. if desired.