### PR TITLE
Pinned jms/serializer to 1.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 before_install:
   - nvm install 6.11
 install:
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.4" ]]; then composer require jms/serializer; fi
   - composer install
   - npm install
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ php:
 #  - nightly
 before_install:
   - nvm install 6.11
+  - sudo apt-get install graphviz
 install:
+  # fix for jms/serializer 1.7.1 not being able to run on 5.4
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.4" ]]; then composer require jms/serializer; fi
   - composer install
   - npm install

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "squizlabs/php_codesniffer": "^3.0.1",
-        "phpdocumentor/phpdocumentor": "~2.9"
+        "phpdocumentor/phpdocumentor": "~2.9",
+        "jms/serializer": "1.7.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixes an issue observed with `jms/serializer` being recently updated to **1.8.0**, which causes phpdoc to fail outright with the following exception and trace:
```
Fatal error: Uncaught exception 'Doctrine\Common\Annotations\AnnotationException' with message '[Semantical Error] The annotation "@JMS\Serializer\Annotation\Type" in property phpDocumentor\Configuration::$title does not exist, or could not be auto-loaded.' in /Users/Bfriedman/Documents/parse-community/parse-php-sdk/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php:54
Stack trace:
#0 /Users/Bfriedman/Documents/parse-community/parse-php-sdk/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php(734): Doctrine\Common\Annotations\AnnotationException::semanticalError('The annotation ...')
#1 /Users/Bfriedman/Documents/parse-community/parse-php-sdk/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php(663): Doctrine\Common\Annotations\DocParser->Annotation()
#2 /Users/Bfriedman/Documents/parse-community/parse-php-sdk/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php(354): Doctrine\Common\Annotations\DocParser->Annotations()
#3 /Use in /Users/Bfriedman/Documents/parse-community/parse-php-sdk/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php on line 54
```