### PR TITLE
Deploy only if php == '7.1'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,6 @@ deploy:
   local_dir: output
   on:
     branch: master
+    php: '7.1'
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Current deployment for latest master runs a `gh-pages` deploy for _every_ version of php we are running against. This clarifies it should only run for **7.1**.