### PR TITLE
Expanding Tests (Curl, Non-Curl, etc.)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
 before_install:
   - nvm install 6.11
   - sudo apt-get install graphviz
-  - if [[ ${NO_CURL} == 1 ]]; then phpenv config-rm curl.ini; fi
 
 install:
   # fix for jms/serializer 1.7.1 not being able to run on 5.4
@@ -33,7 +32,8 @@ before_script:
   - sleep 3
   - npm run lint
 script:
-  - npm run test:coverage
+  - if [[ ${NO_CURL} == 1 ]]; then npm run test-nocurl:coverage; fi
+  - if [[ ! ${NO_CURL} ]]; then npm run test:coverage; fi
   - npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,22 @@ before_script:
   - npm start 1>&2
   - sleep 3
   - npm run lint
-script:
-  - npm run test:coverage
-  - npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
+  
+jobs:
+  include:
+    - stage: test
+      - script: npm run test:coverage
+      - script: npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
+    - stage: stream-test
+      # run one set of tests w/out cURL
+      - php: '5.4'
+      - script: sudo apt-get remove php5-curl
+      - script: npm run test:coverage
+
+#script:
+#  - npm run test:coverage
+#  - npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
+
 before_deploy:
   - npm run document
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 matrix:
   include:
     - php: '5.6'
-      env: NO_CURL=1
+      env: STREAM_CLIENT_ONLY=1
 
 before_install:
   - nvm install 6.11
@@ -32,8 +32,8 @@ before_script:
   - sleep 3
   - npm run lint
 script:
-  - if [[ ${NO_CURL} == 1 ]]; then npm run test-nocurl:coverage; fi
-  - if [[ ! ${NO_CURL} ]]; then npm run test:coverage; fi
+  - if [[ ${STREAM_CLIENT_ONLY} == 1 ]]; then npm run test-stream:coverage; fi
+  - if [[ ! ${STREAM_CLIENT_ONLY} ]]; then npm run test:coverage; fi
   - npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
   include:
     - php: '5.4'
       env: NO_CURL=1
-    - php: '5.4'
-      env:
 
 before_install:
   - nvm install 6.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,18 @@ php:
   - '7.1'
 #  - hhvm # on Trusty only
 #  - nightly
+cache:
+  directories:
+    - node_modules
+    - vendor
+
+matrix:
+  include:
+    - php: '5.4'
+      env: NO_CURL=1
+    - php: '5.4'
+      env:
+
 before_install:
   - nvm install 6.11
   - sudo apt-get install graphviz
@@ -19,21 +31,10 @@ before_script:
   - npm start 1>&2
   - sleep 3
   - npm run lint
-  
-jobs:
-  include:
-    - stage: test
-      - script: npm run test:coverage
-      - script: npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
-    - stage: stream-test
-      # run one set of tests w/out cURL
-      - php: '5.4'
-      - script: sudo apt-get remove php5-curl
-      - script: npm run test:coverage
-
-#script:
-#  - npm run test:coverage
-#  - npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
+script:
+  - if [[ ${NO_CURL} == 1 ]]; then sudo apt-get remove php5-curl; fi
+  - npm run test:coverage
+  - npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
 
 before_deploy:
   - npm run document
@@ -47,3 +48,4 @@ deploy:
     php: '7.1'
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
-  - hhvm # on Trusty only
+#  - hhvm # on Trusty only
 #  - nightly
 cache:
   directories:
@@ -28,6 +28,7 @@ install:
   - composer install
   - npm install
 before_script:
+  - npm stop # clean up cached PID file from prior parse-server
   - npm start 1>&2
   - sleep 3
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 php:
   - '5.4'
   - '5.5'
@@ -14,12 +15,14 @@ cache:
 
 matrix:
   include:
-    - php: '5.4'
+    - php: '5.6'
       env: NO_CURL=1
 
 before_install:
   - nvm install 6.11
   - sudo apt-get install graphviz
+  - if [[ ${NO_CURL} == 1 ]]; then phpenv config-rm curl.ini; fi
+
 install:
   # fix for jms/serializer 1.7.1 not being able to run on 5.4
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.4" ]]; then composer require jms/serializer; fi
@@ -30,7 +33,6 @@ before_script:
   - sleep 3
   - npm run lint
 script:
-  - if [[ ${NO_CURL} == 1 ]]; then sudo apt-get remove php5-curl; fi
   - npm run test:coverage
   - npm run document-check && if [[ `cat "output/checkstyle.xml" | grep "<error "` != "" ]]; then exit 1; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
-#  - hhvm # on Trusty only
+  - hhvm # on Trusty only
 #  - nightly
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "test": "./vendor/bin/phpunit",
     "test:coverage": "./vendor/bin/phpunit --coverage-clover=coverage.xml",
+    "test-stream:coverage": "./vendor/bin/phpunit --bootstrap=./tests/bootstrap-stream.php --coverage-clover=coverage.xml",
     "lint": "./vendor/bin/phpcs --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "lint:fix": "./vendor/bin/phpcbf --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "start" : "./node_modules/parse-server-test/run-server",

--- a/tests/Parse/Helper.php
+++ b/tests/Parse/Helper.php
@@ -65,7 +65,7 @@ class Helper
 
         global $USE_CLIENT_STREAM;
 
-        if(isset($USE_CLIENT_STREAM)) {
+        if (isset($USE_CLIENT_STREAM)) {
             // stream client
             ParseClient::setHttpClient(new ParseStreamHttpClient());
         } else {
@@ -77,7 +77,6 @@ class Helper
                 // stream client
                 ParseClient::setHttpClient(new ParseStreamHttpClient());
             }
-
         }
     }
 

--- a/tests/Parse/Helper.php
+++ b/tests/Parse/Helper.php
@@ -63,12 +63,21 @@ class Helper
         // ParseStreamHttpClient
         //
 
-        if (function_exists('curl_init')) {
-            // cURL client
-            ParseClient::setHttpClient(new ParseCurlHttpClient());
-        } else {
+        global $USE_CLIENT_STREAM;
+
+        if(isset($USE_CLIENT_STREAM)) {
             // stream client
             ParseClient::setHttpClient(new ParseStreamHttpClient());
+        } else {
+            // default client set
+            if (function_exists('curl_init')) {
+                // cURL client
+                ParseClient::setHttpClient(new ParseCurlHttpClient());
+            } else {
+                // stream client
+                ParseClient::setHttpClient(new ParseStreamHttpClient());
+            }
+
         }
     }
 

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -385,7 +385,6 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
                 'not-a-real-endpoint-to-reach',
                 null
             );
-
         }
     }
 
@@ -452,7 +451,6 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
                 '',
                 null
             );
-
         }
     }
 
@@ -499,7 +497,6 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
                 '',
                 null
             );
-
         }
     }
 

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -374,17 +374,19 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testCurlException()
     {
+        if (function_exists('curl_init')) {
+            ParseClient::setHttpClient(new ParseCurlHttpClient());
 
-        ParseClient::setHttpClient(new ParseCurlHttpClient());
+            $this->setExpectedException('\Parse\ParseException', '', 6);
 
-        $this->setExpectedException('\Parse\ParseException', '', 6);
+            ParseClient::setServerURL('http://404.example.com', 'parse');
+            ParseClient::_request(
+                'GET',
+                'not-a-real-endpoint-to-reach',
+                null
+            );
 
-        ParseClient::setServerURL('http://404.example.com', 'parse');
-        ParseClient::_request(
-            'GET',
-            'not-a-real-endpoint-to-reach',
-            null
-        );
+        }
     }
 
     /**
@@ -436,19 +438,22 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testCurlBadRequest()
     {
-        $this->setExpectedException(
-            '\Parse\ParseException',
-            "Bad Request"
-        );
+        if (function_exists('curl_init')) {
+            $this->setExpectedException(
+                '\Parse\ParseException',
+                "Bad Request"
+            );
 
-        ParseClient::setHttpClient(new ParseCurlHttpClient());
+            ParseClient::setHttpClient(new ParseCurlHttpClient());
 
-        ParseClient::setServerURL('http://example.com', '/');
-        ParseClient::_request(
-            'GET',
-            '',
-            null
-        );
+            ParseClient::setServerURL('http://example.com', '/');
+            ParseClient::_request(
+                'GET',
+                '',
+                null
+            );
+
+        }
     }
 
     /**
@@ -476,23 +481,26 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testCurlCAFile()
     {
-        // set a curl client
-        ParseClient::setHttpClient(new ParseCurlHttpClient());
+        if (function_exists('curl_init')) {
+            // set a curl client
+            ParseClient::setHttpClient(new ParseCurlHttpClient());
 
-        // not a real ca file, just testing setting
-        ParseClient::setCAFile("not-real-ca-file");
+            // not a real ca file, just testing setting
+            ParseClient::setCAFile("not-real-ca-file");
 
-        $this->setExpectedException(
-            '\Parse\ParseException',
-            "Bad Request"
-        );
+            $this->setExpectedException(
+                '\Parse\ParseException',
+                "Bad Request"
+            );
 
-        ParseClient::setServerURL('http://example.com', '/');
-        ParseClient::_request(
-            'GET',
-            '',
-            null
-        );
+            ParseClient::setServerURL('http://example.com', '/');
+            ParseClient::_request(
+                'GET',
+                '',
+                null
+            );
+
+        }
     }
 
     /**

--- a/tests/Parse/ParseCurlHttpClientTest.php
+++ b/tests/Parse/ParseCurlHttpClientTest.php
@@ -20,7 +20,6 @@ class ParseCurlHttpClientTest extends \PHPUnit_Framework_TestCase
             $client->send("http://example.com");
 
             $this->assertEquals(200, $client->getResponseStatusCode());
-
         }
     }
 }

--- a/tests/Parse/ParseCurlHttpClientTest.php
+++ b/tests/Parse/ParseCurlHttpClientTest.php
@@ -14,10 +14,13 @@ class ParseCurlHttpClientTest extends \PHPUnit_Framework_TestCase
 {
     public function testResponseStatusCode()
     {
-        $client = new ParseCurlHttpClient();
-        $client->setup();
-        $client->send("http://example.com");
+        if (function_exists('curl_init')) {
+            $client = new ParseCurlHttpClient();
+            $client->setup();
+            $client->send("http://example.com");
 
-        $this->assertEquals(200, $client->getResponseStatusCode());
+            $this->assertEquals(200, $client->getResponseStatusCode());
+
+        }
     }
 }

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -112,15 +112,18 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteCurl()
     {
-        ParseClient::setHttpClient(new ParseCurlHttpClient());
+        if (function_exists('curl_init')) {
+            ParseClient::setHttpClient(new ParseCurlHttpClient());
 
-        $obj = ParseObject::create('TestObject');
-        $obj->set('foo', 'bar');
-        $obj->save();
-        $obj->destroy();
-        $query = new ParseQuery('TestObject');
-        $this->setExpectedException('Parse\ParseException', 'Object not found');
-        $out = $query->get($obj->getObjectId());
+            $obj = ParseObject::create('TestObject');
+            $obj->set('foo', 'bar');
+            $obj->save();
+            $obj->destroy();
+            $query = new ParseQuery('TestObject');
+            $this->setExpectedException('Parse\ParseException', 'Object not found');
+            $out = $query->get($obj->getObjectId());
+
+        }
     }
 
     public function testFind()
@@ -959,19 +962,22 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testSaveAllCurl()
     {
-        ParseClient::setHttpClient(new ParseCurlHttpClient());
+        if (function_exists('curl_init')) {
+            ParseClient::setHttpClient(new ParseCurlHttpClient());
 
-        Helper::clearClass('TestObject');
-        $objs = [];
-        for ($i = 1; $i <= 90; $i++) {
-            $obj = ParseObject::create('TestObject');
-            $obj->set('test', 'test');
-            $objs[] = $obj;
+            Helper::clearClass('TestObject');
+            $objs = [];
+            for ($i = 1; $i <= 90; $i++) {
+                $obj = ParseObject::create('TestObject');
+                $obj->set('test', 'test');
+                $objs[] = $obj;
+            }
+            ParseObject::saveAll($objs);
+            $query = new ParseQuery('TestObject');
+            $result = $query->find();
+            $this->assertEquals(90, count($result));
+
         }
-        ParseObject::saveAll($objs);
-        $query = new ParseQuery('TestObject');
-        $result = $query->find();
-        $this->assertEquals(90, count($result));
     }
 
     /**

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -122,7 +122,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
             $query = new ParseQuery('TestObject');
             $this->setExpectedException('Parse\ParseException', 'Object not found');
             $out = $query->get($obj->getObjectId());
-
         }
     }
 
@@ -976,7 +975,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
             $query = new ParseQuery('TestObject');
             $result = $query->find();
             $this->assertEquals(90, count($result));
-
         }
     }
 

--- a/tests/Parse/ParseSchemaTest.php
+++ b/tests/Parse/ParseSchemaTest.php
@@ -162,26 +162,29 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdateSchemaCurl()
     {
-        ParseClient::setHttpClient(new ParseCurlHttpClient());
+        if (function_exists('curl_init')) {
+            ParseClient::setHttpClient(new ParseCurlHttpClient());
 
-        // create
-        $schema = self::$schema;
-        $schema->addString('name');
-        $schema->save();
-        // update
-        $schema->deleteField('name');
-        $schema->addNumber('quantity');
-        $schema->addField('status', 'Boolean');
-        $schema->update();
-        // get
-        $getSchema = new ParseSchema('SchemaTest');
-        $result = $getSchema->get();
+            // create
+            $schema = self::$schema;
+            $schema->addString('name');
+            $schema->save();
+            // update
+            $schema->deleteField('name');
+            $schema->addNumber('quantity');
+            $schema->addField('status', 'Boolean');
+            $schema->update();
+            // get
+            $getSchema = new ParseSchema('SchemaTest');
+            $result = $getSchema->get();
 
-        if (isset($result['fields']['name'])) {
-            $this->fail('Field not deleted in update action');
+            if (isset($result['fields']['name'])) {
+                $this->fail('Field not deleted in update action');
+            }
+            $this->assertNotNull($result['fields']['quantity']);
+            $this->assertNotNull($result['fields']['status']);
+
         }
-        $this->assertNotNull($result['fields']['quantity']);
-        $this->assertNotNull($result['fields']['status']);
     }
 
     public function testUpdateWrongFieldType()

--- a/tests/Parse/ParseSchemaTest.php
+++ b/tests/Parse/ParseSchemaTest.php
@@ -183,7 +183,6 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
             }
             $this->assertNotNull($result['fields']['quantity']);
             $this->assertNotNull($result['fields']['status']);
-
         }
     }
 

--- a/tests/bootstrap-stream.php
+++ b/tests/bootstrap-stream.php
@@ -3,6 +3,8 @@
 /*
  * Used by the PHPUnit Test Suite to load dependencies and configure the main
  * application path.
+ *
+ * Additionally indicates that the stream client should be used when possible
  */
 
 namespace Parse;
@@ -11,4 +13,7 @@ require_once dirname(__DIR__).'/vendor/autoload.php';
 
 define('APPLICATION_PATH', dirname(__DIR__));
 
-echo "[ testing with curl client ]\n";
+// use the steam client
+$USE_CLIENT_STREAM = true;
+
+echo "[ testing with stream client ]\n";


### PR DESCRIPTION
The test suite can run entirely independent of **curl** by using a stream based client instead. However there are no dedicated tests where a system is devoid of **curl** to test on. This will be an attempt to add one additional test set where **curl** is removed from the system before running tests, but only on php **5.4** to keep test suite size (and time) from being too large or taking too long.