### PR TITLE
Doc Changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,10 @@ Make sure your code is linted with phpcs ([PSR-2 Coding Style]):
 You can automatically fix lint errors with phpcbf:
 
     npm run lint:fix
+    
+Finally verify that your new changes are acceptable to phpdoc:
+
+    npm run document-check
 
 The test suite is setup for code coverage if you have [XDebug] installed and setup.
 Coverage is outputted as text and as html in the phpunit-test-results/ directory within the project root.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ if(ParsePush::hasStatus($response)) {
 Contributing / Testing
 ----------------------
 
-See the CONTRIBUTORS.md file for information on testing and contributing to
+See [CONTRIBUTING](CONTRIBUTING.md) for information on testing and contributing to
 the Parse PHP SDK. We welcome fixes and enhancements.
 
 [Get Composer]: https://getcomposer.org/download/


### PR DESCRIPTION
Adds CONTRIBUTING link to the readme and usage of `document-check` in CONTRIBUTING.md itself. 

`document-check` is utilized in travis to vet new changes for properly parsable documentation, which is later utilized to auto-gen our [api ref](http://parseplatform.org/parse-php-sdk/namespaces/Parse.html).