### PR TITLE
ParseFile use HttpClient for download

### DIFF
--- a/src/Parse/HttpClients/ParseStream.php
+++ b/src/Parse/HttpClients/ParseStream.php
@@ -62,6 +62,9 @@ class ParseStream
         try {
             // get our response
             $response = file_get_contents($url, false, $this->stream);
+            $this->errorMessage = null;
+            $this->errorCode    = null;
+
         } catch (\Exception $e) {
             // set our error message/code and return false
             $this->errorMessage = $e->getMessage();

--- a/src/Parse/HttpClients/ParseStream.php
+++ b/src/Parse/HttpClients/ParseStream.php
@@ -64,7 +64,6 @@ class ParseStream
             $response = file_get_contents($url, false, $this->stream);
             $this->errorMessage = null;
             $this->errorCode    = null;
-
         } catch (\Exception $e) {
             // set our error message/code and return false
             $this->errorMessage = $e->getMessage();

--- a/src/Parse/HttpClients/ParseStreamHttpClient.php
+++ b/src/Parse/HttpClients/ParseStreamHttpClient.php
@@ -169,8 +169,7 @@ class ParseStreamHttpClient implements ParseHttpable
         $this->options['ssl'] = array(
             'verify_peer'       => true,
             'verify_peer_name'  => true,
-            'allow_self_signed' => true, // All root certificates are self-signed
-            'follow_location'   => 1
+            'allow_self_signed' => true // All root certificates are self-signed
         );
     }
 
@@ -233,11 +232,11 @@ class ParseStreamHttpClient implements ParseHttpable
         // get our response headers
         $rawHeaders = $this->parseStream->getResponseHeaders();
 
-        if ($response === false || !$rawHeaders) {
-            // set an error and code
-            $this->streamErrorMessage   = $this->parseStream->getErrorMessage();
-            $this->streamErrorCode      = $this->parseStream->getErrorCode();
-        } else {
+        // set any error and code
+        $this->streamErrorMessage   = $this->parseStream->getErrorMessage();
+        $this->streamErrorCode      = $this->parseStream->getErrorCode();
+
+        if ($response !== false && $rawHeaders) {
             // set our response headers
             $this->responseHeaders = self::formatHeaders($rawHeaders);
 

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -242,8 +242,6 @@ class ParseFile implements Encodable
      */
     private function download()
     {
-        ////// NEW FASHION
-
         $httpClient = ParseClient::getHttpClient();
         $httpClient->setup();
         $response = $httpClient->send($this->url);
@@ -251,38 +249,13 @@ class ParseFile implements Encodable
             throw new ParseException($httpClient->getErrorMessage(), $httpClient->getErrorCode());
         }
         $httpStatus = $httpClient->getResponseStatusCode();
-        if($httpStatus > 399) {
+        if ($httpStatus > 399) {
             throw new ParseException('Download failed, file may have been deleted.', $httpStatus);
         }
         $this->mimeType = $httpClient->getResponseContentType();
         $this->data = $response;
 
         return $response;
-
-
-
-
-        ///// OLD FASHIONED
-
-        /*
-        $rest = curl_init();
-        curl_setopt($rest, CURLOPT_URL, $this->url);
-        curl_setopt($rest, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($rest, CURLOPT_BINARYTRANSFER, 1);
-        $response = curl_exec($rest);
-        if (curl_errno($rest)) {
-            throw new ParseException(curl_error($rest), curl_errno($rest));
-        }
-        $httpStatus = curl_getinfo($rest, CURLINFO_HTTP_CODE);
-        if ($httpStatus > 399) {
-            throw new ParseException('Download failed, file may have been deleted.', $httpStatus);
-        }
-        $this->mimeType = curl_getinfo($rest, CURLINFO_CONTENT_TYPE);
-        $this->data = $response;
-        curl_close($rest);
-
-        return $response;
-        */
     }
 
     /**

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -181,7 +181,7 @@ class ParseFile implements Encodable
     /**
      * Encode to associative array representation.
      *
-     * @return string
+     * @return array
      */
     public function _encode()
     {

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -242,6 +242,29 @@ class ParseFile implements Encodable
      */
     private function download()
     {
+        ////// NEW FASHION
+
+        $httpClient = ParseClient::getHttpClient();
+        $httpClient->setup();
+        $response = $httpClient->send($this->url);
+        if ($httpClient->getErrorCode()) {
+            throw new ParseException($httpClient->getErrorMessage(), $httpClient->getErrorCode());
+        }
+        $httpStatus = $httpClient->getResponseStatusCode();
+        if($httpStatus > 399) {
+            throw new ParseException('Download failed, file may have been deleted.', $httpStatus);
+        }
+        $this->mimeType = $httpClient->getResponseContentType();
+        $this->data = $response;
+
+        return $response;
+
+
+
+
+        ///// OLD FASHIONED
+
+        /*
         $rest = curl_init();
         curl_setopt($rest, CURLOPT_URL, $this->url);
         curl_setopt($rest, CURLOPT_RETURNTRANSFER, 1);
@@ -259,6 +282,7 @@ class ParseFile implements Encodable
         curl_close($rest);
 
         return $response;
+        */
     }
 
     /**

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -2,6 +2,8 @@
 
 namespace Parse\Test;
 
+use Parse\HttpClients\ParseStreamHttpClient;
+use Parse\ParseClient;
 use Parse\ParseException;
 use Parse\ParseFile;
 use Parse\ParseObject;
@@ -93,9 +95,19 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseFileDownloadBadURL()
     {
-        $this->setExpectedException('\Parse\ParseException', '', 6);
+        global $USE_CLIENT_STREAM;
+
+        if(!isset($USE_CLIENT_STREAM)) {
+            // curl exception expectation
+            $this->setExpectedException('\Parse\ParseException', '', 6);
+        } else {
+            // stream exception expectation
+            $this->setExpectedException('\Parse\ParseException', '', 2);
+        }
+
         $file = ParseFile::_createFromServer('file.txt', 'http://404.example.com');
         $file->getData();
+
     }
 
     /**

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -2,9 +2,6 @@
 
 namespace Parse\Test;
 
-use Parse\HttpClients\ParseStreamHttpClient;
-use Parse\ParseClient;
-use Parse\ParseException;
 use Parse\ParseFile;
 use Parse\ParseObject;
 use Parse\ParseQuery;

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -97,7 +97,7 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
     {
         global $USE_CLIENT_STREAM;
 
-        if(!isset($USE_CLIENT_STREAM)) {
+        if (!isset($USE_CLIENT_STREAM)) {
             // curl exception expectation
             $this->setExpectedException('\Parse\ParseException', '', 6);
         } else {
@@ -107,7 +107,6 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
 
         $file = ParseFile::_createFromServer('file.txt', 'http://404.example.com');
         $file->getData();
-
     }
 
     /**


### PR DESCRIPTION
This adjusts downloading for **ParseFile** to perform with the current **HttpClient**, rather than`curl` directly. 

Additionally this includes a fix to **ParseStreamHttpClient** where error messages & codes would not clear between individual requests. This properly cleans up prior errors on subsequent requests.

A couple typo fixes and test adjustments. Removed `follow_location` from the `ssl` options for the stream client, as the parameter is instead for `http` and the default is 1 anyways.

Quick mention, `CURLOPT_BINARYTRANSFER` was not necessary to transfer files as it has [no effect](http://php.net/manual/en/function.curl-setopt.php) from php **5.1.3** onwards. Raw output is always returned with `CURLOPT_RETURNTRANSFER` on it's own.