### PR TITLE
Integration for HHVM Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
-#  - hhvm # on Trusty only
+  - hhvm # on Trusty only
 #  - nightly
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
   include:
     - php: '5.6'
       env: STREAM_CLIENT_ONLY=1
+    - php: hhvm
+      env: STREAM_CLIENT_ONLY=1
 
 before_install:
   - nvm install 6.11

--- a/src/Parse/HttpClients/ParseStreamHttpClient.php
+++ b/src/Parse/HttpClients/ParseStreamHttpClient.php
@@ -235,15 +235,12 @@ class ParseStreamHttpClient implements ParseHttpable
         } else {
             /**
              * HHVM bug bypass
-             *
              * Passing via 'header' ends up duplicating all custom headers submitted due to a bug in HHVM.
              * We can bypass this through the separate 'user_agent' field, as it is never sanitized,
              * so we can append our desired headers after the initial user-agent string.
              * Note that this works in php5 as well (probably 7 and up too),
              * but for now we use this only where we need it.
-             *
-             * HHVM Code in Question:
-             * https://github.com/facebook/hhvm/blob/master/hphp/runtime/base/http-stream-wrapper.cpp#L92
+             * Source: https://github.com/facebook/hhvm/blob/master/hphp/runtime/base/http-stream-wrapper.cpp#L92
              */
             $this->options['http']['user_agent'] = "parse-php-sdk\r\n".$this->buildRequestHeaders();
         }

--- a/src/Parse/HttpClients/ParseStreamHttpClient.php
+++ b/src/Parse/HttpClients/ParseStreamHttpClient.php
@@ -219,7 +219,6 @@ class ParseStreamHttpClient implements ParseHttpable
                 }
 
                 $this->addRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-
             } elseif ($method == "POST") {
                 // handle POST
                 $this->options['http']['content'] = $data;

--- a/src/Parse/ParsePolygon.php
+++ b/src/Parse/ParsePolygon.php
@@ -50,7 +50,7 @@ class ParsePolygon implements Encodable
         }
         $points = [];
         foreach ($coords as $coord) {
-            $geoPoint;
+            $geoPoint = null;
             if ($coord instanceof ParseGeoPoint) {
                 $geoPoint = $coord;
             } elseif (is_array($coord) && count($coord) === 2) {

--- a/tests/Parse/ParseStreamHttpClientTest.php
+++ b/tests/Parse/ParseStreamHttpClientTest.php
@@ -14,6 +14,9 @@ use Parse\ParseException;
 
 class ParseStreamHttpClientTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @group test-get-response
+     */
     public function testGetResponse()
     {
         $client = new ParseStreamHttpClient();
@@ -25,7 +28,7 @@ class ParseStreamHttpClientTest extends \PHPUnit_Framework_TestCase
         // get response headers
         $headers = $client->getResponseHeaders();
 
-        $this->assertEquals('HTTP/1.0 200 OK', $headers['http_code']);
+        $this->assertTrue(preg_match('|HTTP/1\.\d\s200\sOK|', $headers['http_code']) === 1);
     }
 
     public function testInvalidUrl()


### PR DESCRIPTION
This is an attempt to integrate official HHVM support for the parse-php-sdk. Only a couple test changes were needed to be made up front, but the underlying **stream** client seems to misbehave. 

Given that full compatibility will be required for this to move along I'll be tweaking things here to see if I can get the full test suite (with the stream tests) to play nice with hhvm.