### PR TITLE
Fixes Push Status Tests

### DIFF
--- a/tests/Parse/ParsePushTest.php
+++ b/tests/Parse/ParsePushTest.php
@@ -239,13 +239,12 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
         // verify not pending
         $this->assertFalse($pushStatus->isPending());
 
-        // verify 'running'
+        // verify 'running', or 'failed' on later versions of parse-server
+        // both are acceptable
         $this->assertTrue(
-            $pushStatus->isRunning(),
-            'Push did not succeed'
+            $pushStatus->isRunning() || $pushStatus->hasFailed(),
+            'Push did not succeed/fail, was '.$pushStatus->getPushStatus()
         );
-
-
 
         // verify # sent & failed
         $this->assertEquals(
@@ -264,8 +263,7 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             'Hash not present'
         );
 
-        // verify we have neither failed or succeeded
-        $this->assertFalse($pushStatus->hasFailed());
+        // verify we have not succeeded
         $this->assertFalse($pushStatus->hasSucceeded());
     }
 


### PR DESCRIPTION
The latest version of parse-server behaves slightly differently than expected when handling our push status tests. Instead of delivering a success it may deliver failure, which is perfectly acceptable. This modifies an existing test to accept a failure status during normal operation.