### PR TITLE
ParseObject encode/decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ ParseClient::initialize( $app_id, null, $master_key );
 ParseClient::setServerURL('https://my-parse-server.com:port','parse');
 ```
 
-Notice
-Parse server's default port is `1337` and the second parameter `parse` is the route prefix of your parse server.
+Notice Parse server's default port is `1337` and the second parameter `parse` is the route prefix of your parse server.
 
 For example if your parse server's url is `http://example.com:1337/parse` then you can set the server url using the following snippet
 
-`ParseClient::setServerURL('https://example.com:1337','parse');`
+```php
+ParseClient::setServerURL('https://example.com:1337','parse');
+```
 
 Getting Started
 ---------------

--- a/src/Parse/Internal/ParseRelationOperation.php
+++ b/src/Parse/Internal/ParseRelationOperation.php
@@ -117,9 +117,6 @@ class ParseRelationOperation implements FieldOperation
      */
     private function removeObjects($objects, &$container)
     {
-        if (!is_array($objects)) {
-            $objects = [$objects];
-        }
         $nullObjects = [];
         foreach ($objects as $object) {
             if ($object->getObjectId() == null) {
@@ -186,7 +183,7 @@ class ParseRelationOperation implements FieldOperation
                 && $previous->targetClassName != $this->targetClassName
             ) {
                 throw new Exception(
-                    'Related object object must be of class '
+                    'Related object must be of class '
                     .$this->targetClassName.', but '.$previous->targetClassName
                     .' was passed in.',
                     103

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -685,13 +685,10 @@ class ParseObject implements Encodable
     /**
      * Merge data from other object.
      *
-     * @param ParseObject $other
+     * @param ParseObject $other Other object to merge data from
      */
     private function mergeFromObject($other)
     {
-        if (!$other) {
-            return;
-        }
         $this->objectId = $other->getObjectId();
         $this->createdAt = $other->getCreatedAt();
         $this->updatedAt = $other->getUpdatedAt();

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -673,9 +673,6 @@ class ParseObject implements Encodable
                         $decodedValue = new ParseRelation($this, $key, $className);
                     }
                 }
-                if ($key == 'ACL') {
-                    $decodedValue = ParseACL::_createACLFromJSON($decodedValue);
-                }
             }
             $this->serverData[$key] = $decodedValue;
             $this->dataAvailability[$key] = true;

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -1082,29 +1082,24 @@ class ParseObject implements Encodable
                     } else {
                         throw new ParseException("Unrecognized op '{$op}' found during decode.");
                     }
-
                 } else {
                     if (isset($value['__type'])) {
                         // encoded object
                         $obj->_performOperation($key, new SetOperation(ParseClient::_decode($value)));
-
                     } elseif ($key === 'ACL') {
                         // encoded ACL
                         $obj->_performOperation($key, new SetOperation(ParseACL::_createACLFromJSON($value)));
-
                     } else {
                         // array
                         if (count(array_filter(array_keys($value), 'is_string')) > 0) {
                             // associative
                             $obj->_performOperation($key, new SetOperation($value, true));
-
                         } else {
                             // sequential
                             $obj->_performOperation($key, new SetOperation($value));
                         }
                     }
                 }
-
             } else {
                 // set op (not an associative array)
                 $obj->_performOperation($key, new SetOperation($value));

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -917,11 +917,11 @@ class ParseObject implements Encodable
     }
 
     /**
-     * Returns this object as an array representation
+     * Return a JSON encoded value of the object.
      *
-     * @return array
+     * @return string
      */
-    private function toArray()
+    public function _encode()
     {
         $out = [];
         if ($this->objectId) {
@@ -952,17 +952,7 @@ class ParseObject implements Encodable
                 $out[$key] = $value;
             }
         }
-        return $out;
-    }
-
-    /**
-     * Return a JSON encoded value of the object.
-     *
-     * @return string
-     */
-    public function _encode()
-    {
-        return json_encode($this->toArray());
+        return json_encode($out);
     }
 
     /**

--- a/src/Parse/ParseRelation.php
+++ b/src/Parse/ParseRelation.php
@@ -5,6 +5,7 @@
 
 namespace Parse;
 
+use Parse\Internal\Encodable;
 use Parse\Internal\ParseRelationOperation;
 
 /**
@@ -14,7 +15,7 @@ use Parse\Internal\ParseRelationOperation;
  * @author Mohamed Madbouli <mohamedmadbouli@fb.com>
  * @package Parse
  */
-class ParseRelation
+class ParseRelation implements Encodable
 {
     /**
      * The parent of this relation.
@@ -124,4 +125,16 @@ class ParseRelation
 
         return $query;
     }
+
+    public function _encode()
+    {
+        return [
+            '__type'    => 'Relation',
+            'parent'    => $this->parent,
+            'key'       => $this->key,
+            'className' => $this->targetClassName
+        ];
+    }
+
+
 }

--- a/src/Parse/ParseRelation.php
+++ b/src/Parse/ParseRelation.php
@@ -126,15 +126,16 @@ class ParseRelation implements Encodable
         return $query;
     }
 
+    /**
+     * Return an encoded array of this relation.
+     *
+     * @return array
+     */
     public function _encode()
     {
         return [
             '__type'    => 'Relation',
-            'parent'    => $this->parent,
-            'key'       => $this->key,
             'className' => $this->targetClassName
         ];
     }
-
-
 }

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -1576,7 +1576,11 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($obj->getUpdatedAt(), $decoded->getUpdatedAt(), 'Updated at did not match');
         $this->assertEquals($stringVal, $decoded->get('foo'), 'Strings did not match');
         $this->assertEquals($numberVal, $decoded->get('number'), 'Numbers did not match');
-        $this->assertEquals($dateVal, $decoded->get('date'), 'Dates did not match');
+        $this->assertEquals(
+            ParseClient::getProperDateFormat($dateVal),
+            ParseClient::getProperDateFormat($decoded->get('date')),
+            'Dates did not match'
+        );
         $this->assertEquals($boolVal, $decoded->get('bool'), 'Booleans did not match');
         $this->assertEquals(json_decode(json_encode($stdObj), true), $decoded->get('object'), 'Objects did not match');
         $this->assertEquals($arrayVal, $decoded->get('array'), 'Arrays did not match');

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -14,6 +14,7 @@ use Parse\ParseObject;
 use Parse\ParsePolygon;
 use Parse\ParsePushStatus;
 use Parse\ParseQuery;
+use Parse\ParseRelation;
 use Parse\ParseRole;
 use Parse\ParseSession;
 use Parse\ParseUser;
@@ -1383,6 +1384,9 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $obj->destroy();
     }
 
+    /**
+     * @group merge-from-server
+     */
     public function testMergeFromServer()
     {
         $obj = new ParseObject('TestClass');
@@ -1501,6 +1505,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
     {
         $obj = new ParseObject('TestClass');
         $obj->set('value', 'parse-php-sdk!');
+        $obj->set('relation', new ParseRelation($obj, 'relation', 'TestClass'));
 
         $encoded = $obj->encode();
 

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -1498,27 +1498,11 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Runs tests on encoding/decoding an unsaved ParseObject
-     * @group decode-test
+     * Returns an object with one of every type set
+     *
+     * @return ParseObject
      */
-    public function testDecodeOnObject()
-    {
-        $obj = new ParseObject('TestClass');
-        $obj->set('value', 'parse-php-sdk!');
-        $obj->set('relation', new ParseRelation($obj, 'relation', 'TestClass'));
-
-        $encoded = $obj->encode();
-
-        $decoded = ParseObject::decode($encoded);
-
-        $this->assertEquals($obj, $decoded, 'Objects did not match');
-    }
-
-    /**
-     * Runs tests on encoding/decoding a ParseObject that has been saved
-     * @group decode-test
-     */
-    public function testDecodeOnSavedObject()
+    private function getTestObject()
     {
         $obj = new ParseObject('TestClass');
 
@@ -1527,8 +1511,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $numberVal  = 32.23;
         $dateVal    = new \DateTime();
         $boolVal    = false;
-        $stdObj     = new \stdClass();
-        $stdObj->bacon = 2;
         $arrayVal   = ['bar1','bar2'];
         $assocVal   = ['foo1' => 'bar1'];
         $polygon    = new ParsePolygon([[0,0],[0,1],[1,1]]);
@@ -1536,6 +1518,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
         $child      = new ParseObject('TestClass');
         $child->save();
+        $child      = ParseObject::create('TestClass', $child->getObjectId());
 
         $file = ParseFile::createFromData('a file', 'test.txt', 'text/plain');
         $file->save();
@@ -1550,8 +1533,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $obj->set('number', $numberVal);
         $obj->set('date', $dateVal);
         $obj->set('bool', $boolVal);
-        // will be converted to an associative array internally
-        $obj->set('object', $stdObj);
         $obj->setArray('array', $arrayVal);
         $obj->setAssociativeArray('assoc_array', $assocVal);
         $obj->set('pointer', $child);
@@ -1561,9 +1542,71 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $relation = $obj->getRelation('relation', 'TestClass');
         $relation->add([$child]);
 
+        return $obj;
+    }
+
+    /**
+     * Runs tests on encoding/decoding an unsaved ParseObject
+     * @group decode-test
+     */
+    public function testDecodeOnObject()
+    {
+        $obj = $this->getTestObject();
+
+        $encoded = $obj->encode();
+        $decoded = ParseObject::decode($encoded);
+
+        // pull out file to compare separately
+        $decodedFile = $decoded->get('file');
+        $origFile    = $obj->get('file');
+        $decoded->delete('file');
+        $obj->delete('file');
+
+        $this->assertEquals($obj, $decoded, 'Objects did not match');
+
+        // check files separately
+        $this->assertEquals($origFile->_encode(), $decodedFile->_encode(), 'Files did not match');
+
+        $this->assertTrue($obj->has('foo'));
+        $obj->revert();
+        $this->assertFalse($obj->has('foo'));
+    }
+
+    /**
+     * Runs tests on encoding/decoding a ParseObject that has been saved
+     *
+     * @group decode-test
+     */
+    public function testDecodeOnSavedObject()
+    {
+        // setup IVs
+        $stringVal  = 'this-is-foo';
+        $numberVal  = 32.23;
+        $dateVal    = new \DateTime();
+        $boolVal    = false;
+        $arrayVal   = ['bar1','bar2'];
+        $assocVal   = ['foo1' => 'bar1'];
+        $polygon    = new ParsePolygon([[0,0],[0,1],[1,1]]);
+        $geoPoint   = new ParseGeoPoint(1, 0);
+
+        $child      = new ParseObject('TestClass');
+        $child->save();
+        $child      = ParseObject::create('TestClass', $child->getObjectId());
+
+        $obj = $this->getTestObject();
+
+        // change to a pointer we can check against
+        $obj->set('pointer', $child);
+        $relation = $obj->getRelation('relation', 'TestClass');
+        $relation->remove([$child]);
+
+        // not testing file comparisons, as the the content type differs slightly
+        // this is tested above in 'testDecodeOnObject'
+        $obj->delete('file');
+
         $obj->save();
 
-        // add one unsaved modification to test
+        // add an unsaved modifications
         $obj->set('unsaved', 'not a saved value');
 
         $encoded = $obj->encode();
@@ -1573,7 +1616,8 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($decoded->getCreatedAt(), 'Created at was not set');
         $this->assertNotNull($decoded->getUpdatedAt(), 'Updated at was not set');
 
-        $this->assertEquals($encoded, $decoded->encode(), 'Encoded strings did not match');
+        //$this->assertEquals($encoded, $decoded->encode(), 'Encoded strings did not match');
+        $this->assertEquals($obj, $decoded, 'Decoded object did not match original');
 
         // verify IVs
         $this->assertEquals($obj->getObjectId(), $decoded->getObjectId(), 'Object ids did not match');
@@ -1587,14 +1631,12 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
             'Dates did not match'
         );
         $this->assertEquals($boolVal, $decoded->get('bool'), 'Booleans did not match');
-        $this->assertEquals(json_decode(json_encode($stdObj), true), $decoded->get('object'), 'Objects did not match');
         $this->assertEquals($arrayVal, $decoded->get('array'), 'Arrays did not match');
         $this->assertEquals($assocVal, $decoded->get('assoc_array'), 'Associative arrays did not match');
         $pointee = $decoded->get('pointer');
         $pointee->fetch();
         $child->fetch();
         $this->assertEquals($child->_encode(), $pointee->_encode(), 'Pointers did not match');
-        $this->assertEquals($file->getData(), $decoded->get('file')->getData(), 'Files did not match');
         $this->assertEquals($polygon, $decoded->get('polygon'), 'Polygons did not match');
         $this->assertEquals($geoPoint, $decoded->get('geopoint'), 'Geopoints did not match');
 
@@ -1604,9 +1646,8 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         // verify relation
         $relation = $decoded->getRelation('relation', 'TestClass');
         $query = $relation->getQuery();
-        $found = $query->first();
-        $this->assertNotNull($found);
-        $this->assertEquals($child->getObjectId(), $found->getObjectId());
+        $found = $query->find();
+        $this->assertEquals(1, count($found));
 
         // attempt to add another object to this relation
         $child2 = new ParseObject('TestClass');
@@ -1616,11 +1657,85 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $query->count());
 
         // attempt to remove objects from this relation
-        $relation->remove([$child, $child2]);
+        $relation->remove([$found[0], $child2]);
         $decoded->save();
         $this->assertEquals(0, $query->count());
 
         // cleanup
-        $decoded->destroy();
+        ParseObject::destroyAll([$decoded,$child]);
+    }
+
+    /**
+     * Tests decoding with various ops
+     *
+     * @group decode-test
+     */
+    public function testDecodeWithOps()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->set('number', 5);
+        $obj->setArray('array', ['apples']);
+        $obj->setArray('uniquearray', ['apples']);
+        $obj->setArray('removearray', ['apples']);
+        $obj->save();
+
+        // add op
+        $obj->add('array', ['bananas']);
+
+        // unique op
+        $obj->addUnique('uniquearray', ['unique-value']);
+
+        // remove op
+        $obj->remove('removearray', 'apples');
+
+        // delete op
+        $obj->delete('foo');
+
+        // increment op
+        $obj->increment('number', 5);
+
+        // remove relation op
+        $child = new ParseObject('TestClass');
+        $child->save();
+        $child = ParseObject::create('TestClass', $child->getObjectId());
+
+        $child2 = new ParseObject('TestClass');
+        $child2->save();
+        $child2 = ParseObject::create('TestClass', $child2->getObjectId());
+
+        $relation = $obj->getRelation('relation3', 'TestClass');
+        $relation->add([$child]);
+        $relation->remove([$child2]);
+
+        $relation = $obj->getRelation('relation4', 'TestClass');
+        $relation->remove([$child]);
+
+        $encoded = $obj->encode();
+
+        $decoded = ParseObject::decode($encoded);
+
+        $this->assertEquals($obj, $decoded, 'Decoded object did not match');
+    }
+
+    /**
+     * Tests decoding with an unrecognized op
+     *
+     * @group decode-unrecognized-test
+     */
+    public function testUnrecognizedOp()
+    {
+        $this->setExpectedException(
+            '\Parse\ParseException',
+            "Unrecognized op 'Unrecognized' found during decode."
+        );
+
+        $obj = new ParseObject('TestClass');
+        $encoded = $obj->encode();
+        $encoded = json_decode($encoded, true);
+        $encoded['operationSet'][] = [
+            '__op'  => 'Unrecognized'
+        ];
+        ParseObject::decode($encoded);
+
     }
 }

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -1509,7 +1509,12 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         // setup IVs
         $stringVal  = 'this-is-foo';
         $numberVal  = 32.23;
+
+        // use a 'clean' date value
         $dateVal    = new \DateTime();
+        $dateVal    = ParseClient::_encode($dateVal, false);
+        $dateVal    = ParseClient::_decode($dateVal);
+
         $boolVal    = false;
         $arrayVal   = ['bar1','bar2'];
         $assocVal   = ['foo1' => 'bar1'];
@@ -1582,7 +1587,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         // setup IVs
         $stringVal  = 'this-is-foo';
         $numberVal  = 32.23;
-        $dateVal    = new \DateTime();
         $boolVal    = false;
         $arrayVal   = ['bar1','bar2'];
         $assocVal   = ['foo1' => 'bar1'];
@@ -1626,7 +1630,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($stringVal, $decoded->get('foo'), 'Strings did not match');
         $this->assertEquals($numberVal, $decoded->get('number'), 'Numbers did not match');
         $this->assertEquals(
-            ParseClient::getProperDateFormat($dateVal),
+            ParseClient::getProperDateFormat($obj->get('date')),
             ParseClient::getProperDateFormat($decoded->get('date')),
             'Dates did not match'
         );

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -1572,6 +1572,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         // check files separately
         $this->assertEquals($origFile->_encode(), $decodedFile->_encode(), 'Files did not match');
 
+        // check that we can still revert these changes
         $this->assertTrue($obj->has('foo'));
         $obj->revert();
         $this->assertFalse($obj->has('foo'));

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -1736,6 +1736,5 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
             '__op'  => 'Unrecognized'
         ];
         ParseObject::decode($encoded);
-
     }
 }

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -1531,7 +1531,6 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
         $child      = new ParseObject('TestClass');
         $child->save();
-        $child->fetch();
 
         $file = ParseFile::createFromData('a file', 'test.txt', 'text/plain');
         $file->save();
@@ -1584,6 +1583,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($assocVal, $decoded->get('assoc_array'), 'Associative arrays did not match');
         $pointee = $decoded->get('pointer');
         $pointee->fetch();
+        $child->fetch();
         $this->assertEquals($child->_encode(), $pointee->_encode(), 'Pointers did not match');
         $this->assertEquals($file->getData(), $decoded->get('file')->getData(), 'Files did not match');
         $this->assertEquals($polygon, $decoded->get('polygon'), 'Polygons did not match');

--- a/tests/Parse/ParseRelationOperationTest.php
+++ b/tests/Parse/ParseRelationOperationTest.php
@@ -123,7 +123,7 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(
             '\Exception',
-            'Related object object must be of class '
+            'Related object must be of class '
             .'Class1, but AnotherClass'
             .' was passed in.'
         );
@@ -163,5 +163,15 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
         ParseRelationOperation::removeElementsFromArray('removeThis', $array);
 
         $this->assertEmpty($array);
+    }
+
+    /**
+     * @group relation-remove-missing-object-id
+     */
+    public function testRemoveMissingObjectId()
+    {
+        $obj = new ParseObject('Class1');
+        $op = new ParseRelationOperation(null, $obj);
+        $op->_mergeWithPrevious(new ParseRelationOperation(null, $obj));
     }
 }


### PR DESCRIPTION
This proposes to add new **encode** and **decode** to the **ParseObject** class. These would be separate from the previously existing `ParseObject::_encode`, which remains unmodified in terms of prior behavior.

This is essentially a lighter and more integrated approach as opposed just using `serialize` and `unserialize`. Through this an object could be encoded or decoded as follows.
```php
$obj = new ParseObject('MyClass');
// set some values...

// encode
$encoded = $obj->encode();
// NOTE this is not the same as the previously existing _encode

// do something with your encoded object...

// decode
$decoded = ParseObject::decode($encoded);
```

Currently this will preserve saved _and_ unsaved values, allowing you to encode an object with unsaved changes preserved until later decoded.

A few notes as to how this works with specific values:
- Scalars are preserved as is
- instances of DateTime are recognized and encoded separately of other objects, so that a DateTime object is returned during decoding
- 
- Pointers are stripped down, as in they'll have to be fetched to get data later (this is to prevent cyclical references)
- Keep in mind objects (like instances of `stdClass`, but not ParseObjects, ParsePolygons, ParseGeoPoints, etc.) will be encoded to JSON if possible and returned as an array value (this is how it works currently)
- Relations will not preserve unsaved additions/removals during encoding

As it stands this is good to go. The only issue being about preserving the pending set of operations that have been applied to an object (like the aforementioned concern of unsaved additions/removals in a relation). I might still make a few changes yet, and if I have the time I may make the change to support pending ops.

This also includes a small style change to the README.