### PR TITLE
Server Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,40 @@ if(ParsePush::hasStatus($response)) {
 }
 ```
 
+Server Info:
+
+Get information regarding the configuration of the server you are connecting to.
+```php
+// get the current version of the server you are connected to (2.6.5, 2.5.4, etc.)
+$version = ParseServerInfo::getVersion();
+
+// get various features
+$globalConfigFeatures = ParseServerInfo::getGlobalConfigFeatures();
+/**
+ * Returns json of the related features
+ * {
+ *    "create" : true,
+ *    "read"   : true,
+ *    "update" : true,
+ *    "delete" : true
+ * }
+ */
+```
+
+ You can get details on the following features as well:
+
+ ```php
+ ParseServerInfo::getHooksFeatures();
+ ParseServerInfo::getCloudCodeFeatures();
+ ParseServerInfo::getLogsFeatures();
+ ParseServerInfo::getPushFeatures();
+ ParseServerInfo::getSchemasFeatures();
+
+ // additional features can be obtained manually using 'get'
+ $feature = ParseServerInfo::get('new-feature');
+
+ ```
+
 Contributing / Testing
 ----------------------
 

--- a/src/Parse/ParseServerInfo.php
+++ b/src/Parse/ParseServerInfo.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 10/30/17
+ * Time: 15:56
+ */
+
+namespace Parse;
+
+/**
+ * Class ParseFeatures - Representation of server-side features
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
+ * @package Parse
+ */
+class ParseServerInfo
+{
+    /**
+     * Reported server features and configs
+     *
+     * @var array
+     */
+    private static $serverFeatures;
+
+    /**
+     * Reported server version
+     *
+     * @var string
+     */
+    private static $serverVersion;
+
+    /**
+     * Requests and sets server features and version
+     *
+     * @throws ParseException
+     */
+    private static function setServerInfo()
+    {
+        $info = ParseClient::_request(
+            'GET',
+            'serverInfo/',
+            null,
+            null,
+            true
+        );
+
+        // validate we have features & version
+
+        if(!isset($info['features'])) {
+            throw new ParseException('Missing features in server info.');
+        }
+
+        if(!isset($info['parseServerVersion'])) {
+            throw new ParseException('Missing version in server info');
+        }
+
+        self::$serverFeatures = $info['features'];
+        self::$serverVersion  = $info['parseServerVersion'];
+    }
+
+    /**
+     * Get a specific feature set from the server
+     *
+     * @param string $key   Feature set to get
+     * @return mixed
+     */
+    public static function get($key)
+    {
+        if(!isset(self::$serverFeatures)) {
+            self::setServerInfo();
+        }
+        return self::$serverFeatures[$key];
+    }
+
+    /**
+     * Gets features for the current server
+     *
+     * @return array
+     */
+    public static function getFeatures()
+    {
+        if(!isset(self::$serverFeatures)) {
+            self::setServerInfo();
+        }
+        return self::$serverFeatures;
+    }
+
+    /**
+     * Gets the reported version of the current server
+     *
+     * @return string
+     */
+    public static function getVersion()
+    {
+        if(!isset(self::$serverVersion)) {
+            self::setServerInfo();
+        }
+        return self::$serverVersion;
+    }
+
+    /**
+     * Gets features available for globalConfig
+     *
+     * @return array
+     */
+    public static function getGlobalConfigFeatures()
+    {
+        return self::get('globalConfig');
+    }
+
+    /**
+     * Gets features available for hooks
+     *
+     * @return array
+     */
+    public static function getHooksFeatures()
+    {
+        return self::get('hooks');
+    }
+
+    /**
+     * Gets features available for cloudCode
+     *
+     * @return array
+     */
+    public static function getCloudCodeFeatures()
+    {
+        return self::get('cloudCode');
+    }
+
+    /**
+     * Gets features available for logs
+     *
+     * @return array
+     */
+    public static function getLogsFeatures()
+    {
+        return self::get('logs');
+    }
+
+    /**
+     * Gets features available for push
+     *
+     * @return array
+     */
+    public static function getPushFeatures()
+    {
+        return self::get('push');
+    }
+
+    /**
+     * Gets features available for schemas
+     *
+     * @return array
+     */
+    public static function getSchemasFeatures()
+    {
+        return self::get('schemas');
+    }
+}

--- a/src/Parse/ParseServerInfo.php
+++ b/src/Parse/ParseServerInfo.php
@@ -54,7 +54,7 @@ class ParseServerInfo
             }
 
             if (!isset($info['parseServerVersion'])) {
-                throw new ParseException('Missing version in server info');
+                throw new ParseException('Missing version in server info.');
             }
 
             self::$serverFeatures = $info['features'];

--- a/src/Parse/ParseServerInfo.php
+++ b/src/Parse/ParseServerInfo.php
@@ -1,9 +1,6 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: Bfriedman
- * Date: 10/30/17
- * Time: 15:56
+ * Class ParseServerInfo | Parse/ParseServerInfo.php
  */
 
 namespace Parse;
@@ -11,7 +8,7 @@ namespace Parse;
 /**
  * Class ParseFeatures - Representation of server-side features
  *
- * @author Ben Friedman <ben@axolsoft.com>
+ * @author Ben Friedman <friedman.benjamin@gmail.com>
  * @package Parse
  */
 class ParseServerInfo

--- a/src/Parse/ParseServerInfo.php
+++ b/src/Parse/ParseServerInfo.php
@@ -47,11 +47,11 @@ class ParseServerInfo
 
         // validate we have features & version
 
-        if(!isset($info['features'])) {
+        if (!isset($info['features'])) {
             throw new ParseException('Missing features in server info.');
         }
 
-        if(!isset($info['parseServerVersion'])) {
+        if (!isset($info['parseServerVersion'])) {
             throw new ParseException('Missing version in server info');
         }
 
@@ -67,7 +67,7 @@ class ParseServerInfo
      */
     public static function get($key)
     {
-        if(!isset(self::$serverFeatures)) {
+        if (!isset(self::$serverFeatures)) {
             self::setServerInfo();
         }
         return self::$serverFeatures[$key];
@@ -80,7 +80,7 @@ class ParseServerInfo
      */
     public static function getFeatures()
     {
-        if(!isset(self::$serverFeatures)) {
+        if (!isset(self::$serverFeatures)) {
             self::setServerInfo();
         }
         return self::$serverFeatures;
@@ -93,7 +93,7 @@ class ParseServerInfo
      */
     public static function getVersion()
     {
-        if(!isset(self::$serverVersion)) {
+        if (!isset(self::$serverVersion)) {
             self::setServerInfo();
         }
         return self::$serverVersion;

--- a/src/Parse/ParseServerInfo.php
+++ b/src/Parse/ParseServerInfo.php
@@ -38,7 +38,7 @@ class ParseServerInfo
      */
     private static function getServerInfo()
     {
-        if(!isset(self::$serverFeatures) || !isset(self::$serverVersion)) {
+        if (!isset(self::$serverFeatures) || !isset(self::$serverVersion)) {
             $info = ParseClient::_request(
                 'GET',
                 'serverInfo/',

--- a/tests/Parse/ParseServerInfoTest.php
+++ b/tests/Parse/ParseServerInfoTest.php
@@ -8,7 +8,6 @@
 
 namespace Parse\Test;
 
-
 use Parse\ParseServerInfo;
 
 class ParseServerInfoTest extends \PHPUnit_Framework_TestCase
@@ -90,5 +89,4 @@ class ParseServerInfoTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($schemasFeatures['editClassLevelPermissions']);
         $this->assertTrue($schemasFeatures['editPointerPermissions']);
     }
-
 }

--- a/tests/Parse/ParseServerInfoTest.php
+++ b/tests/Parse/ParseServerInfoTest.php
@@ -24,10 +24,27 @@ class ParseServerInfoTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($features);
     }
 
+    /**
+     * @group test-get-version
+     */
     public function testGetVersion()
     {
+        ParseServerInfo::_setServerVersion(null);
         $version = ParseServerInfo::getVersion();
         $this->assertNotNull($version);
+    }
+
+    public function testSetVersion()
+    {
+        /**
+         * Tests setting the version.
+         * /health may return the version in the future as well.
+         * Rather than fetch that information again we can always have the option
+         * to set it from wherever we happen to get it.
+         */
+        $version = '1.2.3';
+        ParseServerInfo::_setServerVersion($version);
+        $this->assertEquals($version, ParseServerInfo::getVersion());
     }
 
     public function testGlobalConfigFeatures()

--- a/tests/Parse/ParseServerInfoTest.php
+++ b/tests/Parse/ParseServerInfoTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 10/30/17
+ * Time: 16:35
+ */
+
+namespace Parse\Test;
+
+
+use Parse\ParseServerInfo;
+
+class ParseServerInfoTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDirectGet()
+    {
+        $logs = ParseServerInfo::get('logs');
+        $this->assertNotNull($logs);
+    }
+
+    public function testGetFeatures()
+    {
+        $features = ParseServerInfo::getFeatures();
+        $this->assertNotEmpty($features);
+    }
+
+    public function testGetVersion()
+    {
+        $version = ParseServerInfo::getVersion();
+        $this->assertNotNull($version);
+    }
+
+    public function testGlobalConfigFeatures()
+    {
+        $globalConfigFeatures = ParseServerInfo::getGlobalConfigFeatures();
+        $this->assertTrue($globalConfigFeatures['create']);
+        $this->assertTrue($globalConfigFeatures['read']);
+        $this->assertTrue($globalConfigFeatures['update']);
+        $this->assertTrue($globalConfigFeatures['delete']);
+    }
+
+    public function testHooksFeatures()
+    {
+        $hooksFeatures = ParseServerInfo::getHooksFeatures();
+        $this->assertTrue($hooksFeatures['create']);
+        $this->assertTrue($hooksFeatures['read']);
+        $this->assertTrue($hooksFeatures['update']);
+        $this->assertTrue($hooksFeatures['delete']);
+    }
+
+    public function testCloudCodeFeatures()
+    {
+        $cloudCodeFeatures = ParseServerInfo::getCloudCodeFeatures();
+        $this->assertTrue($cloudCodeFeatures['jobs']);
+    }
+
+    public function testLogsFeatures()
+    {
+        $logsFeatures = ParseServerInfo::getLogsFeatures();
+        $this->assertTrue($logsFeatures['level']);
+        $this->assertTrue($logsFeatures['size']);
+        $this->assertTrue($logsFeatures['order']);
+        $this->assertTrue($logsFeatures['until']);
+        $this->assertTrue($logsFeatures['from']);
+    }
+
+    public function testPushFeatures()
+    {
+        $pushFeatures = ParseServerInfo::getPushFeatures();
+
+        // these may change depending on the server being tested against
+        $this->assertTrue(isset($pushFeatures['immediatePush']));
+        $this->assertTrue(isset($pushFeatures['scheduledPush']));
+        $this->assertTrue(isset($pushFeatures['storedPushData']));
+
+        $this->assertTrue($pushFeatures['pushAudiences']);
+        $this->assertTrue($pushFeatures['localization']);
+    }
+
+    public function testSchemasFeatures()
+    {
+        $schemasFeatures = ParseServerInfo::getSchemasFeatures();
+        $this->assertTrue($schemasFeatures['addField']);
+        $this->assertTrue($schemasFeatures['removeField']);
+        $this->assertTrue($schemasFeatures['addClass']);
+        $this->assertTrue($schemasFeatures['removeClass']);
+        $this->assertTrue($schemasFeatures['clearAllDataFromClass']);
+        $this->assertFalse($schemasFeatures['exportClass']);
+        $this->assertTrue($schemasFeatures['editClassLevelPermissions']);
+        $this->assertTrue($schemasFeatures['editPointerPermissions']);
+    }
+
+}

--- a/tests/bootstrap-stream.php
+++ b/tests/bootstrap-stream.php
@@ -22,4 +22,4 @@ $USE_CLIENT_STREAM = true;
 Helper::setUp();
 $version = ParseServerInfo::getVersion();
 
-echo "[ testing with stream client ]\n";
+echo "[ testing against {$version} with stream client ]\n";

--- a/tests/bootstrap-stream.php
+++ b/tests/bootstrap-stream.php
@@ -9,11 +9,17 @@
 
 namespace Parse;
 
+use Parse\Test\Helper;
+
 require_once dirname(__DIR__).'/vendor/autoload.php';
 
 define('APPLICATION_PATH', dirname(__DIR__));
 
 // use the steam client
 $USE_CLIENT_STREAM = true;
+
+// indicate which server version & client we're testing against
+Helper::setUp();
+$version = ParseServerInfo::getVersion();
 
 echo "[ testing with stream client ]\n";

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,8 +7,14 @@
 
 namespace Parse;
 
+use Parse\Test\Helper;
+
 require_once dirname(__DIR__).'/vendor/autoload.php';
 
 define('APPLICATION_PATH', dirname(__DIR__));
 
-echo "[ testing with curl client ]\n";
+// indicate which server version & client we're testing against
+Helper::setUp();
+$version = ParseServerInfo::getVersion();
+
+echo "[ testing against {$version} with curl client ]\n";


### PR DESCRIPTION
Adds the `ParseServerInfo` class for handling server-side information provided by `/serverInfo`. This additionally includes the reported server version. This, and additional data can be accessed via the aforementioned class to see the various features of the current server and it's available features.

This doesn't modify any existing functionality, but it does add a convenient reporting aspect in terms of server version and general configuration/features.