### PR TITLE
Account for relative time keywords 'now','week' & 'year'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ from your PHP app or script.  Designed to work with the self-hosted Parse Server
     - [Users](#users)
     - [ACLs/Security](#acls)
     - [Queries](#queries)
+        - [Relative Time](#relative-time)
     - [Cloud Functions](#cloud-functions)
     - [Analytics](#analytics)
     - [Files](#files)
@@ -278,6 +279,28 @@ $first = $query->first();
 $query->each(function($obj) {
     echo $obj->getObjectId();
 });
+```
+
+#### Relative Time
+
+Queries can be made using relative time, allowing you to retrieve objects over a varying ranges of relative dates.
+Keep in mind that all relative queries are performed using the server's time and timezone.
+```php
+// greater than 2 weeks ago
+$query->greaterThanRelativeTime('createdAt', '2 weeks ago');
+
+// less than 1 day in the future
+$query->lessThanRelativeTime('updatedAt', 'in 1 day');
+
+// can make queries to very specific points in time
+$query->greaterThanOrEqualToRelativeTime('createdAt', '1 year 2 weeks 30 days 2 hours 5 minutes 10 seconds ago');
+
+// can make queries based on right now
+// gets everything updated up to this point in time
+$query->lessThanOrEqualToRelativeTime('updatedAt', 'now');
+
+// shorthand keywords work as well
+$query->greaterThanRelativeTime('date', '1 yr 2 wks 30 d 2 hrs 5 mins 10 secs ago');
 ```
 
 ### Cloud Functions

--- a/tests/Parse/ParseQueryRelativeTimeTest.php
+++ b/tests/Parse/ParseQueryRelativeTimeTest.php
@@ -27,13 +27,13 @@ class ParseQueryRelativeTimeTest extends \PHPUnit_Framework_TestCase
 
     public function provideDateTestObjects()
     {
-        // 4 days ago
         $obj = new ParseObject('TestObject');
         $obj->save();
 
         // use server date
         $baselineDate = $obj->getCreatedAt()->format('m/d/Y H:i:s');
 
+        // 4 days ago
         $date = \DateTime::createFromFormat('m/d/Y H:i:s', $baselineDate);
         $date->sub((new \DateInterval('P4D')));
         $obj->set('date', $date);
@@ -60,6 +60,46 @@ class ParseQueryRelativeTimeTest extends \PHPUnit_Framework_TestCase
         $obj = new ParseObject('TestObject');
         $date = \DateTime::createFromFormat('m/d/Y H:i:s', $baselineDate);
         $date->add((new \DateInterval('P4D')));
+        $obj->set('date', $date);
+        $obj->set('name', 'obj4');
+        $obj->save();
+    }
+
+    public function provideExtendedDateTestObjects()
+    {
+        $obj = new ParseObject('TestObject');
+        $obj->save();
+
+        // use server date
+        $baselineDate = $obj->getCreatedAt()->format('m/d/Y H:i:s');
+
+        // 1 year 20 days ago
+        $date = \DateTime::createFromFormat('m/d/Y H:i:s', $baselineDate);
+        $date->sub((new \DateInterval('P01Y20D')));
+        $obj->set('date', $date);
+        $obj->set('name', 'obj1');
+        $obj->save();
+
+        // 1 year 8 days ago
+        $obj = new ParseObject('TestObject');
+        $date = \DateTime::createFromFormat('m/d/Y H:i:s', $baselineDate);
+        $date->sub((new \DateInterval('P01Y8D')));
+        $obj->set('date', $date);
+        $obj->set('name', 'obj2');
+        $obj->save();
+
+        // 1 year 8 days from now
+        $obj = new ParseObject('TestObject');
+        $date = \DateTime::createFromFormat('m/d/Y H:i:s', $baselineDate);
+        $date->add((new \DateInterval('P01Y8D')));
+        $obj->set('date', $date);
+        $obj->set('name', 'obj3');
+        $obj->save();
+
+        // 1 year 20 days from now
+        $obj = new ParseObject('TestObject');
+        $date = \DateTime::createFromFormat('m/d/Y H:i:s', $baselineDate);
+        $date->add((new \DateInterval('P01Y20D')));
         $obj->set('date', $date);
         $obj->set('name', 'obj4');
         $obj->save();
@@ -203,7 +243,7 @@ class ParseQueryRelativeTimeTest extends \PHPUnit_Framework_TestCase
 
         // shorthand units
         $query = new ParseQuery('TestObject');
-        $query->greaterThanRelativeTime('date', 'in 3 days 2 hrs 15 mins 30 secs');
+        $query->greaterThanRelativeTime('date', 'in 3 d 2 hrs 15 mins 30 secs');
         $this->assertEquals(1, $query->count());
 
         // singular units
@@ -213,8 +253,52 @@ class ParseQueryRelativeTimeTest extends \PHPUnit_Framework_TestCase
 
         // singular shorthand units
         $query = new ParseQuery('TestObject');
-        $query->greaterThanRelativeTime('date', 'in 3 days 1 hr 1 min 1 sec');
+        $query->greaterThanRelativeTime('date', 'in 3 d 1 hr 1 min 1 sec');
         $this->assertEquals(1, $query->count());
+    }
+
+    /**
+     * @group relative-time-queries
+     */
+    public function testLongRelativeTime()
+    {
+        $this->provideExtendedDateTestObjects();
+
+        $query = new ParseQuery('TestObject');
+        $query->greaterThanRelativeTime('date', 'in 1 year 2 weeks');
+        $this->assertEquals(1, $query->count());
+
+        $query = new ParseQuery('TestObject');
+        $query->lessThanRelativeTime('date', '1 yr 2 wks ago');
+        $this->assertEquals(1, $query->count());
+
+        $query = new ParseQuery('TestObject');
+        $query->lessThanRelativeTime('date', '1 year 3 weeks ago');
+        $this->assertEquals(0, $query->count());
+
+        $query = new ParseQuery('TestObject');
+        $query->greaterThanRelativeTime('date', 'in 1 year 3 weeks');
+        $this->assertEquals(0, $query->count());
+
+        $query = new ParseQuery('TestObject');
+        $query->greaterThanRelativeTime('date', '1 year 3 weeks ago');
+        $this->assertEquals(4, $query->count());
+    }
+
+    /**
+     * @group relative-time-queries
+     */
+    public function testNowRelativeTime()
+    {
+        $this->provideDateTestObjects();
+
+        $query = new ParseQuery('TestObject');
+        $query->greaterThanRelativeTime('date', 'now');
+        $this->assertEquals(2, $query->count());
+
+        $query = new ParseQuery('TestObject');
+        $query->lessThanRelativeTime('date', 'now');
+        $this->assertEquals(2, $query->count());
     }
 
     /**


### PR DESCRIPTION
Accounts for the recently added relative time keywords `now`, `week` and `year`. In addition to their shorthands, `wk` and `yr`. This also add usages in the README to demonstrate functionality.