### PR TITLE
Adds Purge & Polygon to ParseSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ from your PHP app or script.  Designed to work with the self-hosted Parse Server
     - [Server Info](#server-info)
         - [Version](#version)
         - [Features](#features)
+    - [Schema](#schema)
+        - [Purge](#purge)
 - [Contributing / Testing](#contributing--testing)
 
 ## Installation
@@ -476,6 +478,61 @@ $globalConfigFeatures = ParseServerInfo::getGlobalConfigFeatures();
  $feature = ParseServerInfo::get('new-feature');
 
  ```
+
+### Schema
+Direct manipulation of the classes that are on your server is possible through `ParseSchema`.
+Although fields and classes can be automatically generated (the latter assuming client class creation is enabled) `ParseSchema` gives you explicit control over these classes and their fields.
+```php
+// create an instance to manage your class
+$mySchema = new ParseSchema("MyClass");
+
+// gets the current schema data as an associative array, for inspection
+$data = $mySchema->get();
+
+// add any # of fields, without having to create any objects
+$mySchema->addString('string_field');
+$mySchema->addNumber('num_field');
+$mySchema->addBoolean('bool_field');
+$mySchema->addDate('date_field');
+$mySchema->addFile('file_field');
+$mySchema->addGeoPoint('geopoint_field');
+$mySchema->addPolygon('polygon_field');
+$mySchema->addArray('array_field');
+$mySchema->addObject('obj_field');
+$mySchema->addPointer('pointer_field');
+
+// you can even setup pointer/relation fields this way
+$mySchema->addPointer('pointer_field', 'TargetClass');
+$mySchema->addRelation('relation_field', 'TargetClass');
+
+// new types can be added as they are available
+$mySchema->addField('new_field', 'ANewDataType');
+
+// save/update this schema to persist your field changes
+$mySchema->save();
+// or
+$mySchema->update();
+
+```
+Assuming you want to remove a field you can simply call `deleteField` and `save/update` to clear it out.
+```php
+$mySchema->deleteField('string_field');
+$mySchema->save():
+// or for an existing schema...
+$mySchema->update():
+```
+A schema can be removed via `delete`, but it must be empty first.
+```php
+$mySchema->delete();
+```
+
+#### Purge
+All objects can be purged from a schema (class) via `purge`. But be careful! This can be considered an irreversible action.
+Only do this if you _really_ need to delete all objects from a class, such as when you need to delete the class (as in the code example above).
+```php
+// delete all objects in the schema
+$mySchema->purge();
+```
 
 ## Contributing / Testing
 

--- a/src/Parse/ParseSchema.php
+++ b/src/Parse/ParseSchema.php
@@ -283,7 +283,7 @@ class ParseSchema
             $this->useMasterKey
         );
 
-        if(!empty($result)) {
+        if (!empty($result)) {
             throw new Exception('Error on purging all objects from schema "'.$this->className.'"');
         }
     }

--- a/src/Parse/ParseSchema.php
+++ b/src/Parse/ParseSchema.php
@@ -62,6 +62,13 @@ class ParseSchema
     public static $GEO_POINT = 'GeoPoint';
 
     /**
+     * Polygon data type
+     *
+     * @var string
+     */
+    public static $POLYGON = 'Polygon';
+
+    /**
      * Array data type
      *
      * @var string
@@ -474,6 +481,28 @@ class ParseSchema
     }
 
     /**
+     * Adding Polygon Field.
+     *
+     * @param string $fieldName Name of the field will created on Parse
+     *
+     * @throws \Exception
+     *
+     * @return ParseSchema fields return self to create field on Parse
+     */
+    public function addPolygon($fieldName = null)
+    {
+        if (!$fieldName) {
+            throw new Exception('field name may not be null.', 105);
+        }
+
+        $this->fields[$fieldName] = [
+            'type' => self::$POLYGON,
+        ];
+
+        return $this;
+    }
+
+    /**
      * Adding Array Field.
      *
      * @param string $fieldName Name of the field will created on Parse
@@ -612,6 +641,7 @@ class ParseSchema
             $type !== self::$DATE &&
             $type !== self::$FILE &&
             $type !== self::$GEO_POINT &&
+            $type !== self::$POLYGON &&
             $type !== self::$ARRAY &&
             $type !== self::$OBJECT &&
             $type !== self::$POINTER &&

--- a/src/Parse/ParseSchema.php
+++ b/src/Parse/ParseSchema.php
@@ -259,6 +259,29 @@ class ParseSchema
     }
 
     /**
+     * Removes all objects from a Schema (class) in Parse.
+     * EXERCISE CAUTION, running this will delete all objects for this schema and cannot be reversed
+     *
+     * @throws Exception
+     */
+    public function purge()
+    {
+        self::assertClassName();
+
+        $result = ParseClient::_request(
+            'DELETE',
+            'purge/'.$this->className,
+            null,
+            null,
+            $this->useMasterKey
+        );
+
+        if(!empty($result)) {
+            throw new Exception('Error on purging all objects from schema "'.$this->className.'"');
+        }
+    }
+
+    /**
      * Removing a Schema from Parse.
      * You can only remove a schema from your app if it is empty (has 0 objects).
      *

--- a/tests/Parse/ParseSchemaTest.php
+++ b/tests/Parse/ParseSchemaTest.php
@@ -75,6 +75,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(ParseSchema::$DATE, $result['fields']['dateField']['type']);
         $this->assertEquals(ParseSchema::$FILE, $result['fields']['fileField']['type']);
         $this->assertEquals(ParseSchema::$GEO_POINT, $result['fields']['geoPointField']['type']);
+        $this->assertEquals(ParseSchema::$POLYGON, $result['fields']['polygonField']['type']);
         $this->assertEquals(ParseSchema::$ARRAY, $result['fields']['arrayField']['type']);
         $this->assertEquals(ParseSchema::$OBJECT, $result['fields']['objectField']['type']);
         $this->assertEquals(ParseSchema::$POINTER, $result['fields']['pointerField']['type']);
@@ -93,6 +94,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
             ->addDate('dateField')
             ->addFile('fileField')
             ->addGeoPoint('geoPointField')
+            ->addPolygon('polygonField')
             ->addArray('arrayField')
             ->addObject('objectField')
             ->addPointer('pointerField', '_User')
@@ -316,6 +318,13 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
         $schema = self::$schema;
         $this->setExpectedException('\Exception', 'field name may not be null.');
         $schema->addGeoPoint();
+    }
+
+    public function testPolygonFieldNameException()
+    {
+        $schema = self::$schema;
+        $this->setExpectedException('\Exception', 'field name may not be null.');
+        $schema->addPolygon();
     }
 
     public function testArrayFieldNameException()

--- a/tests/Parse/ParseSchemaTest.php
+++ b/tests/Parse/ParseSchemaTest.php
@@ -216,7 +216,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
         try {
             $schema->delete();
             $this->assertTrue(false, 'Did not fail on delete as expected');
-        } catch(ParseException $pe) {
+        } catch (ParseException $pe) {
             $this->assertEquals(
                 'Class SchemaTest is not empty, contains 1 objects, cannot drop schema.',
                 $pe->getMessage()


### PR DESCRIPTION
This adds the `purge` method to `ParseSchema`. This allows the deletion of _all_ objects without having to run through and query all objects for removal. This was added to `ParseSchema` as the related `delete` method requires the class to be first empty of objects.

Polygon type support has also been added to `ParseSchema`, both via a suported method to add a polygon type field and as a recognized field when asserting types.