### PR TITLE
Add ability to upgrade to a revocable session

### DIFF
--- a/src/Parse/ParseSession.php
+++ b/src/Parse/ParseSession.php
@@ -86,6 +86,24 @@ class ParseSession extends ParseObject
         return strpos($token, 'r:') === 0;
     }
 
+    public static function upgradeToRevocableSession()
+    {
+        $token = ParseUser::getCurrentUser()->getSessionToken();
+        $response = ParseClient::_request(
+            'POST',
+            'upgradeToRevocableSession',
+            $token,
+            null,
+            false
+        );
+        $session = new self();
+        $session->_mergeAfterFetch($response);
+        $session->handleSaveResult();
+        ParseUser::become($session->getSessionToken());
+
+        //echo "\n\nGOT RESPONSE: ".json_encode($response) . "\n\n";
+    }
+
     /**
      * After a save, perform Session object specific logic.
      */

--- a/src/Parse/ParseSession.php
+++ b/src/Parse/ParseSession.php
@@ -86,22 +86,30 @@ class ParseSession extends ParseObject
         return strpos($token, 'r:') === 0;
     }
 
+    /**
+     * Upgrades the current session to a revocable one
+     *
+     * @throws ParseException
+     */
     public static function upgradeToRevocableSession()
     {
-        $token = ParseUser::getCurrentUser()->getSessionToken();
-        $response = ParseClient::_request(
-            'POST',
-            'upgradeToRevocableSession',
-            $token,
-            null,
-            false
-        );
-        $session = new self();
-        $session->_mergeAfterFetch($response);
-        $session->handleSaveResult();
-        ParseUser::become($session->getSessionToken());
-
-        //echo "\n\nGOT RESPONSE: ".json_encode($response) . "\n\n";
+        $user = ParseUser::getCurrentUser();
+        if ($user) {
+            $token = $user->getSessionToken();
+            $response = ParseClient::_request(
+                'POST',
+                'upgradeToRevocableSession',
+                $token,
+                null,
+                false
+            );
+            $session = new self();
+            $session->_mergeAfterFetch($response);
+            $session->handleSaveResult();
+            ParseUser::become($session->getSessionToken());
+        } else {
+            throw new ParseException('No session to upgrade.');
+        }
     }
 
     /**

--- a/tests/Parse/ParseSessionTest.php
+++ b/tests/Parse/ParseSessionTest.php
@@ -56,4 +56,27 @@ class ParseSessionTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Parse\ParseException', 'invalid session token');
         ParseUser::become($sessionToken);
     }
+
+    /**
+     * @group upgrade-to-revocable-session
+     */
+    public function testUpgradeToRevocableSession()
+    {
+        $user = new ParseUser();
+        $user->setUsername('revocable_username');
+        $user->setPassword('revocable_password');
+        $user->signUp();
+
+        $session = ParseSession::getCurrentSession();
+        $this->assertEquals($user->getSessionToken(), $session->getSessionToken());
+
+        // upgrade the current session (changes our session as well)
+        ParseSession::upgradeToRevocableSession();
+
+        // verify that our session has changed, and our updated current user matches it
+        $session = ParseSession::getCurrentSession();
+        $user = ParseUser::getCurrentUser();
+        $this->assertEquals($user->getSessionToken(), $session->getSessionToken());
+        $this->assertTrue($session->isCurrentSessionRevocable());
+    }
 }

--- a/tests/Parse/ParseSessionTest.php
+++ b/tests/Parse/ParseSessionTest.php
@@ -79,4 +79,14 @@ class ParseSessionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($user->getSessionToken(), $session->getSessionToken());
         $this->assertTrue($session->isCurrentSessionRevocable());
     }
+
+    /**
+     * @group upgrade-to-revocable-session
+     */
+    public function testBadUpgradeToRevocableSession()
+    {
+        // upgrade the current session (changes our session as well)
+        $this->setExpectedException('Parse\ParseException', 'No session to upgrade.');
+        ParseSession::upgradeToRevocableSession();
+    }
 }


### PR DESCRIPTION
This adds `ParseSession::upgradeToRevocableSession`, which mirrors the name of the endpoint it utilizes to upgrade an existing session to a revocable one. Adds appropriate tests as needed to verify that the current user is also updated to reflect this, both on the server and locally in storage.