### PR TITLE
Adds ability to Request Verification Emails

### DIFF
--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -608,6 +608,22 @@ class ParseUser extends ParseObject
     }
 
     /**
+     * Request a verification email to be sent to the specified email address
+     *
+     * @param string $email Email to request a verification for
+     */
+    public static function requestVerificationEmail($email)
+    {
+        $json = json_encode(['email' => $email]);
+        ParseClient::_request(
+            'POST',
+            'verificationEmailRequest',
+            null,
+            $json
+        );
+    }
+
+    /**
      * Sets the current user to null. Used internally for testing purposes.
      */
     public static function _clearCurrentUserVariable()

--- a/tests/Parse/ParseUserTest.php
+++ b/tests/Parse/ParseUserTest.php
@@ -718,4 +718,35 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
         ParseUser::logOut();
     }
+
+    /**
+     * @group verification-email
+     */
+    public function testRequestVerificationEmail()
+    {
+        $user = new ParseUser();
+        $user->setUsername('verification_email_user');
+        $user->setPassword('password');
+        $user->setEmail('example@example.com');
+        $user->signUp();
+        ParseUser::requestVerificationEmail('example@example.com');
+    }
+
+    /**
+     * @group verification-email
+     */
+    public function testRequestVerificationEmailEmpty()
+    {
+        $this->setExpectedException('Parse\ParseException', 'you must provide an email');
+        ParseUser::requestVerificationEmail('');
+    }
+
+    /**
+     * @group verification-email
+     */
+    public function testRequestVerificationEmailBad()
+    {
+        $this->setExpectedException('Parse\ParseException', 'No user found with email not_a_known_email');
+        ParseUser::requestVerificationEmail('not_a_known_email');
+    }
 }

--- a/tests/Parse/ParseUserTest.php
+++ b/tests/Parse/ParseUserTest.php
@@ -724,12 +724,34 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
      */
     public function testRequestVerificationEmail()
     {
+        $email = 'example@example.com';
         $user = new ParseUser();
         $user->setUsername('verification_email_user');
         $user->setPassword('password');
-        $user->setEmail('example@example.com');
+        $user->setEmail($email);
         $user->signUp();
-        ParseUser::requestVerificationEmail('example@example.com');
+        ParseUser::requestVerificationEmail($email);
+    }
+
+    /**
+     * @group verification-email
+     */
+    public function testEmailAlreadyVerified()
+    {
+        $email = 'example2@example.com';
+        $this->setExpectedException('Parse\ParseException', "Email {$email} is already verified.");
+
+        $user = new ParseUser();
+        $user->setUsername('another_verification_email_user');
+        $user->setPassword('password');
+        $user->setEmail($email);
+        $user->signUp();
+
+        // forcibly update emailVerification status
+        $user->set('emailVerified', true);
+        $user->save(true);
+
+        ParseUser::requestVerificationEmail($email);
     }
 
     /**


### PR DESCRIPTION
This adds the ability to request that a verification email be sent for a given email. This does not require the current user to be logged in, just needs the `email` arg to be that of an existing non-verified user.