### PR TITLE
Adds set/save to ParseConfig

### DIFF
--- a/src/Parse/ParseConfig.php
+++ b/src/Parse/ParseConfig.php
@@ -44,6 +44,17 @@ class ParseConfig
     }
 
     /**
+     * Sets a config value
+     *
+     * @param string $key   Key to set value on
+     * @param mixed $value  Value to set
+     */
+    public function set($key, $value)
+    {
+        $this->currentConfig[$key] = $value;
+    }
+
+    /**
      * Gets a config value with html characters encoded
      *
      * @param string $key   Key of value to get
@@ -75,5 +86,24 @@ class ParseConfig
     public function getConfig()
     {
         return $this->currentConfig;
+    }
+
+    /**
+     * Saves the current config
+     *
+     * @return bool
+     */
+    public function save()
+    {
+        $response = ParseClient::_request(
+            'PUT',
+            'config',
+            null,
+            json_encode([
+                'params'    => $this->currentConfig
+            ]),
+            true
+        );
+        return $response['result'];
     }
 }

--- a/tests/Parse/ParseConfigTest.php
+++ b/tests/Parse/ParseConfigTest.php
@@ -11,6 +11,12 @@ class ParseConfigTest extends \PHPUnit_Framework_TestCase
         Helper::setUp();
     }
 
+    public function tearDown()
+    {
+        // clear config on tear down
+        Helper::clearClass('_GlobalConfig');
+    }
+
     /**
      * @group parse-config
      */
@@ -51,5 +57,19 @@ class ParseConfigTest extends \PHPUnit_Framework_TestCase
 
         // check normal value
         $this->assertEquals('bar', $config->escape('foo'));
+    }
+
+    /**
+     * @group parse-config
+     */
+    public function testSaveConfig()
+    {
+        $config = new ParseConfig();
+        $this->assertNull($config->get('key'));
+        $config->set('key', 'value');
+        $config->save();
+
+        $config = new ParseConfig();
+        $this->assertEquals($config->get('key'), 'value');
     }
 }


### PR DESCRIPTION
This adds set/save functionality to `ParseConfig`, which interacts with the `_GlobalConfig` collection server-side (of which there should only ever be one instance). Associated tests are added as well.

You can set/save as follows.
```php
// gets the current parse config
$config = new ParseConfig();

// sets a new key/value pair in the config
$config->set('key', 'value');

// saves the current config back to the server
$config->save(); // internally uses the masterKey to save
```