### PR TITLE
(Fix) Logout User before proceeding with some Query Tests

### DIFF
--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -210,9 +210,9 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
     {
 
         $user = ParseUser::getCurrentUser();
-
         if (isset($user)) {
-            throw new ParseException($user->_encode());
+            // logout the current user
+            ParseUser::logOut();
         }
 
         $this->provideTestObjects(10);


### PR DESCRIPTION
Fixes some bad test code where an exception is thrown if a user is logged in. Should instead logout the user and proceed normally.