### PR TITLE
Silence License warning by using allowed wording to point to a local file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "type": "git",
     "url": "git+https://github.com/parse-community/parse-php-sdk"
   },
-  "license": "https://github.com/parse-community/parse-php-sdk/blob/master/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/montymxb/parse-server-test#readme",
   "dependencies": {
     "parse-server-test": "1.3.4"


### PR DESCRIPTION
see: https://docs.npmjs.com/files/package.json#license