### PR TITLE
Update parse-server-test to 1.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please note that this documentation contains the latest changes that may as of y
 
 ## Installation
 There are various ways to install and use this sdk. We'll elaborate on a couple here.
-Note that the Parse PHP SDK requires PHP 5.4 or newer. It can also run on **HHVM** (recommended 3.0 or newer).
+Note that the Parse PHP SDK requires PHP 5.4 or newer. It can also run on HHVM (recommended 3.0 or newer).
 
 ### Install with Composer
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please note that this documentation contains the latest changes that may as of y
 
 ## Installation
 There are various ways to install and use this sdk. We'll elaborate on a couple here.
-Note that the Parse PHP SDK requires PHP 5.4 or newer.
+Note that the Parse PHP SDK requires PHP 5.4 or newer. It can also run on **HHVM** (recommended 3.0 or newer).
 
 ### Install with Composer
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/montymxb/parse-server-test#readme",
   "dependencies": {
-    "parse-server-test": "1.3.4"
+    "parse-server-test": "1.3.5"
   }
 }

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -252,7 +252,10 @@ class ParseFile implements Encodable
         if ($httpStatus > 399) {
             throw new ParseException('Download failed, file may have been deleted.', $httpStatus);
         }
-        $this->mimeType = $httpClient->getResponseContentType();
+        $mimeType = $httpClient->getResponseContentType();
+        if(isset($mimeType) && $mimeType !== 'null') {
+            $this->mimeType = $mimeType;
+        }
         $this->data = $response;
 
         return $response;

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -253,7 +253,7 @@ class ParseFile implements Encodable
             throw new ParseException('Download failed, file may have been deleted.', $httpStatus);
         }
         $mimeType = $httpClient->getResponseContentType();
-        if(isset($mimeType) && $mimeType !== 'null') {
+        if (isset($mimeType) && $mimeType !== 'null') {
             $this->mimeType = $mimeType;
         }
         $this->data = $response;

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -146,7 +146,12 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($contents, $file3Again->getData());
 
         // check mime types after calling getData
-        $this->assertEquals('application/octet-stream', $fileAgain->getMimeType());
+        $mt = $fileAgain->getMimeType();
+        $this->assertTrue(
+            // both of the following are acceptable for a response from a submitted mime type of unknown/unknown
+            $mt === 'application/octet-stream' ||  // parse-server < 2.7.0
+            $mt === 'unknown/unknown'                       // parse-server >= 2.7.0, unknown/unknown mime type response change
+        );
         $this->assertEquals('image/png', $file2Again->getMimeType());
         $this->assertEquals('image/png', $file3Again->getMimeType());
     }

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -147,10 +147,10 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
 
         // check mime types after calling getData
         $mt = $fileAgain->getMimeType();
+        // both of the following are acceptable for a response from a submitted mime type of unknown/unknown
         $this->assertTrue(
-            // both of the following are acceptable for a response from a submitted mime type of unknown/unknown
             $mt === 'application/octet-stream' ||  // parse-server < 2.7.0
-            $mt === 'unknown/unknown'                       // parse-server >= 2.7.0, unknown/unknown mime type response change
+            $mt === 'unknown/unknown'                       // parse-server >= 2.7.0, unknown mime type response change
         );
         $this->assertEquals('image/png', $file2Again->getMimeType());
         $this->assertEquals('image/png', $file3Again->getMimeType());


### PR DESCRIPTION
Updates our server testing dependency to **1.3.5** to address package name changes.