### PR TITLE
don't foreach bad responses

### DIFF
--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -599,6 +599,9 @@ class ParseQuery
             null,
             $useMasterKey
         );
+        if (!isset($result['results'])) {
+            $result = [];
+        }
         $output = [];
         foreach ($result['results'] as $row) {
             $obj = ParseObject::create($this->className, $row['objectId']);


### PR DESCRIPTION
If ```ParseClient::_request()``` gets a bad response and ```self::$enableCurlExceptions``` is not enabled when ```ParseQuery::find()``` runs it creates PHP warnings because it's trying to foreach a bool. This should help prevent some non useful noise.