### PR TITLE
Adds Fix for Changed Push Status Life Cycle

### DIFF
--- a/tests/Parse/ParsePushTest.php
+++ b/tests/Parse/ParsePushTest.php
@@ -237,11 +237,11 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
         // verify not pending
         $this->assertFalse($pushStatus->isPending());
 
-        // verify 'running', or 'failed' on later versions of parse-server
+        // verify 'running', or 'failed'/'succeeded' on later versions of parse-server
         // both are acceptable
         $this->assertTrue(
-            $pushStatus->isRunning() || $pushStatus->hasFailed(),
-            'Push did not succeed/fail, was '.$pushStatus->getPushStatus()
+            $pushStatus->isRunning() || $pushStatus->hasFailed() || $pushStatus->hasSucceeded(),
+            'Push was not running/succeeded/failed, was '.$pushStatus->getPushStatus()
         );
 
         // verify # sent & failed
@@ -261,8 +261,13 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             'Hash not present'
         );
 
-        // verify we have not succeeded
-        $this->assertFalse($pushStatus->hasSucceeded());
+        if ($pushStatus->hasFailed()) {
+            // verify we have not succeeded
+            $this->assertFalse($pushStatus->hasSucceeded());
+        } else {
+            // verify we have succeeded (later servers)
+            $this->assertTrue($pushStatus->hasSucceeded());
+        }
     }
 
     /**


### PR DESCRIPTION
This adds a small fix to our test suite that was affected by a change to the push status life cycle. Originally we could create a dummy set of pushes and expect it to be marked as 'failed'. That has since changed to be marked as 'succeeded'. In terms of functionality nothing has really changed, but the reported push statuses didn't match up with what we were expecting.

The adjustment to the tests should still pass with servers using the old push status life cycle.