### PR TITLE
Fix queries equalTo with null values

### DIFF
--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -112,11 +112,7 @@ class ParseQuery
      */
     public function equalTo($key, $value)
     {
-        if ($value === null) {
-            $this->doesNotExist($key);
-        } else {
-            $this->where[$key] = $value;
-        }
+        $this->where[$key] = $value;
 
         return $this;
     }

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -2115,11 +2115,20 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
                 return $obj;
             }
         );
+        $this->saveObjects(
+            2,
+            function ($i) {
+                $obj = ParseObject::create('TestObject');
+                $obj->set('num', null);
+
+                return $obj;
+            }
+        );
         $query = new ParseQuery('TestObject');
         $query->equalTo('num', null);
         $results = $query->find();
         $this->assertEquals(
-            0,
+            2,
             count($results),
             'Did not return correct number of objects.'
         );


### PR DESCRIPTION

| Q  | A |
| ------------- | ------------- |
| Branch?  | master |
| Bug fix?  | yes |
| New feature?  | no |
| BC breaks?  | possible |
| Deprecations?  | no |
| Tests pass?  | yes |

Hello,

This fix is meant to correct the behavior when we do an ->equalTo(null) ParseQuery.
Before that, it used ->doesNotExist($key) which can work if the attribute has never been set, but if the attribute is set and equals to NULL, then it does not match.

The only workaround I found to effectively query on NULL values before this patch is to do an ->notContainedIn($key, [null]) which is not pretty and not accurate.

I think there is no reason to replace a "IS NULL" query part by a "DOES NOT EXISTS", they both mean something different and the SDK users must choose one or the other according to their needs.
