### PR TITLE
Avoid session fixation by regenerating session id on user promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
 - Adds Purge & Polygon to ParseSchema (#365)
 - Adds Parse Server Health Check (#366)
 - Adds the ability to upgrade to a revocable session (#368)
+- Avoid session fixation exploit by regenerating session id's (#414)
 - Adds ability to Request Verification Emails (#369)
-- Adds the ability to set/save in `ParseConfig` (#371) 
+- Adds the ability to set/save in `ParseConfig` (#371)
 - Adds `ParseLogs` (#370)
 - Adds `ParseAudience` (#372)
 - Adds jobs to `ParseCloud` (#373)
@@ -40,7 +41,7 @@
 
 - Updates to make the sdk friendly with `phpdoc`
 - Added **Getting Started** section to README
-- Removed the default server and mount path for `api.parse.com` 
+- Removed the default server and mount path for `api.parse.com`
 - Setup `phpdoc` style enforcing and autodeploy from most recent `master` for our [api ref](http://parseplatform.org/parse-php-sdk/namespaces/Parse.html)
 - **jms/serializer** pinned to **1.7.1** for testing as mentioned in #336 (for phpdoc)
 - Added **ParsePolygon** type and `polygonContains` to **ParseQuery** (thanks to [Diamond Lewis](https://github.com/dplewis))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 - Adds Purge & Polygon to ParseSchema (#365)
 - Adds Parse Server Health Check (#366)
 - Adds the ability to upgrade to a revocable session (#368)
-- Avoid session fixation exploit by regenerating session id's (#414)
 - Adds ability to Request Verification Emails (#369)
 - Adds the ability to set/save in `ParseConfig` (#371)
 - Adds `ParseLogs` (#370)

--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ try {
 // Current user
 $user = ParseUser::getCurrentUser();
 ```
+#### Session Id and Session Fixation
+In an attempt to avoid [session fixation exploits](https://www.owasp.org/index.php/Session_fixation), the PHP SDK will call [`session_regenerate_id()`](http://php.net/manual/en/function.session-regenerate-id.php) when a session's permissions are elevated (since 1.5.0).  In practice this means that `session_regenerate_id()` will be called when a session goes from no user, to anonymous user; or from no user or anonymous user to registered user.
+
+Changing the PHP session id should have no impact on the contents of the session and state should me maintained for a user that was anonymous and becomes registered.
 
 #### Verification Emails
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Please note that this documentation contains the latest changes that may as of y
     - [Use Declarations](#use-declarations)
     - [Parse Objects](#parse-objects)
     - [Users](#users)
+        - [Session Id and Session Fixation](#session-id-and-session-fixation)
         - [Verification Emails](#verification-emails)
     - [ACLs/Security](#acls)
     - [Queries](#queries)

--- a/README.md
+++ b/README.md
@@ -290,9 +290,9 @@ try {
 $user = ParseUser::getCurrentUser();
 ```
 #### Session Id and Session Fixation
-In an attempt to avoid [session fixation exploits](https://www.owasp.org/index.php/Session_fixation), the PHP SDK will call [`session_regenerate_id()`](http://php.net/manual/en/function.session-regenerate-id.php) when a session's permissions are elevated (since 1.5.0).  In practice this means that `session_regenerate_id()` will be called when a session goes from no user, to anonymous user; or from no user or anonymous user to registered user.
+In an attempt to avoid [session fixation exploits](https://www.owasp.org/index.php/Session_fixation), the PHP SDK will call [`session_regenerate_id()`](http://php.net/manual/en/function.session-regenerate-id.php) when a session's permissions are elevated (since 1.5.0).  In practice this means that `session_regenerate_id()` will be called when a session goes from no user to anonymous user or from no user / anonymous user to registered user.
 
-Changing the PHP session id should have no impact on the contents of the session and state should me maintained for a user that was anonymous and becomes registered.
+Changing the PHP session id should have no impact on the contents of the session and state should be maintained for a user that was anonymous and becomes registered.
 
 #### Verification Emails
 

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -500,6 +500,10 @@ class ParseUser extends ParseObject
             unset($this->serverData['sessionToken']);
         }
         if ($makeCurrent) {
+            if (session_id()) {
+                // see: https://www.owasp.org/index.php/Session_fixation
+                session_regenerate_id();
+            }
             static::$currentUser = $this;
             static::saveCurrentUser();
         }

--- a/tests/Parse/ParseSessionFixationTest.php
+++ b/tests/Parse/ParseSessionFixationTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace Parse\Test;
+
+use Parse\ParseClient;
+use Parse\ParseUser;
+use Parse\ParseSession;
+
+class ParseSessionFixationTest extends \PHPUnit_Framework_TestCase
+{
+
+    public static function setUpBeforeClass()
+    {
+        Helper::clearClass(ParseUser::$parseClassName);
+        Helper::clearClass(ParseSession::$parseClassName);
+        ParseUser::logout();
+        ParseClient::_unsetStorage();
+
+        // indicate we should not use cookies
+        ini_set("session.use_cookies", 0);
+        // indicate we can use something other than cookies
+        ini_set("session.use_only_cookies", 0);
+        // enable transparent sid support, for url based sessions
+        ini_set("session.use_trans_sid", 1);
+        // clear cache control for session pages
+        ini_set("session.cache_limiter", "");
+        session_start();
+        Helper::setUp();
+    }
+
+    public function tearDown()
+    {
+        Helper::tearDown();
+        Helper::clearClass(ParseUser::$parseClassName);
+        Helper::clearClass(ParseSession::$parseClassName);
+        ParseUser::logout();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        session_destroy();
+    }
+
+    public function testCookieIdChangedForAnonymous()
+    {
+        ParseClient::getStorage()->set('test', 'hi');
+        $noUserSessionId = session_id();
+        $user = ParseUser::loginWithAnonymous();
+        $anonymousSessionId = session_id();
+        $this->assertNotEquals($noUserSessionId, $anonymousSessionId);
+        $this->assertEquals(ParseClient::getStorage()->get('test'), 'hi');
+    }
+
+    public function testCookieIdChangedForAnonymousToRegistered()
+    {
+        $user = ParseUser::loginWithAnonymous();
+        $anonymousSessionId = session_id();
+        ParseClient::getStorage()->set('test', 'hi');
+        $user->setUsername('testy');
+        $user->setPassword('testy');
+        $user->save();
+        $user->login('testy', 'testy');
+        $registeredSessionId = session_id();
+        $this->assertNotEquals($anonymousSessionId, $registeredSessionId);
+        $this->assertEquals(ParseClient::getStorage()->get('test'), 'hi');
+    }
+}


### PR DESCRIPTION
Fixes: #413

