### PR TITLE
Add encode option to ParseQuery:find

### DIFF
--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -610,10 +610,11 @@ class ParseQuery
      * Execute a find query and return the results.
      *
      * @param bool $useMasterKey
+     * @param bool $decodeObjects If set to false, will not return raw data instead of ParseObject instances
      *
      * @return ParseObject[]
      */
-    public function find($useMasterKey = false)
+    public function find($useMasterKey = false, $decodeObjects = true)
     {
         $sessionToken = null;
         if (ParseUser::getCurrentUser()) {
@@ -627,6 +628,13 @@ class ParseQuery
             null,
             $useMasterKey
         );
+        if (!$decodeObjects) {
+            if (array_key_exists('results', $result)) {
+                return $result['results'];
+            } else {
+                return [];
+            }
+        }
         $output = [];
         foreach ($result['results'] as $row) {
             $obj = ParseObject::create($this->className, $row['objectId']);

--- a/tests/Parse/Helper.php
+++ b/tests/Parse/Helper.php
@@ -52,7 +52,7 @@ class Helper
         self::setHttpClient();
     }
 
-    public static function setHttpClient()
+    public static function setHttpClient($httpClient = null)
     {
         //
         // Set a curl http client to run primary tests under
@@ -61,6 +61,9 @@ class Helper
         // ParseCurlHttpClient
         // ParseStreamHttpClient
         //
+        if ($httpClient) {
+            return ParseClient::setHttpClient($httpClient);
+        }
 
         global $USE_CLIENT_STREAM;
 

--- a/tests/Parse/HttpClientMock.php
+++ b/tests/Parse/HttpClientMock.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Class HttpClientMock | Parse/Test/HttpClientMock.php
+ */
+
+namespace Parse\Test;
+
+use Parse\HttpClients\ParseCurlHttpClient;
+
+class HttpClientMock extends ParseCurlHttpClient
+{
+    private $response = '';
+
+    public function send($url, $method = 'GET', $data = array())
+    {
+        return $this->response;
+    }
+
+    public function setResponse($resp)
+    {
+        $this->response = $resp;
+    }
+}

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -2408,6 +2408,9 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         $results = $query->find(false, false);
 
         $this->assertEquals(0, count($results));
+
+        // Reset HttpClient
+        Helper::setUp();
     }
 
     /**

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -2365,6 +2365,34 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
+    public function testQueryFindEncoded()
+    {
+        $obj = new ParseObject('TestObject');
+        $obj->set('name', 'John');
+        $obj->set('country', 'US');
+        $obj->save();
+
+        $obj = new ParseObject('TestObject');
+        $obj->set('name', 'Bob');
+        $obj->set('country', 'US');
+        $obj->save();
+
+        $obj = new ParseObject('TestObject');
+        $obj->set('name', 'Joel');
+        $obj->set('country', 'CA');
+        $obj->save();
+
+        $query = new ParseQuery('TestObject');
+        $query->ascending(['country','name']);
+        $results = $query->find(false, false);
+
+        $this->assertEquals(3, count($results));
+
+        $this->assertEquals('Joel', $results[0]['name']);
+        $this->assertEquals('Bob', $results[1]['name']);
+        $this->assertEquals('John', $results[2]['name']);
+    }
+
     /**
      * @group query-set-conditions
      */

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -2383,7 +2383,7 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         $obj->save();
 
         $query = new ParseQuery('TestObject');
-        $query->ascending(['country','name']);
+        $query->ascending(['country', 'name']);
         $results = $query->find(false, false);
 
         $this->assertEquals(3, count($results));
@@ -2391,6 +2391,23 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Joel', $results[0]['name']);
         $this->assertEquals('Bob', $results[1]['name']);
         $this->assertEquals('John', $results[2]['name']);
+    }
+
+    public function testQueryFindEncodedInvalidResponse()
+    {
+        $obj = new ParseObject('TestObject');
+        $obj->set('name', 'John');
+        $obj->set('country', 'US');
+        $obj->save();
+
+        $httpClient = new HttpClientMock();
+        $httpClient->setResponse('{}');
+        Helper::setHttpClient($httpClient);
+
+        $query = new ParseQuery('TestObject');
+        $results = $query->find(false, false);
+
+        $this->assertEquals(0, count($results));
     }
 
     /**


### PR DESCRIPTION
the ability to get the result from a ParseQuery->find() without the results being decoded into ParseObject instances.

Similar to https://github.com/parse-community/parse-php-sdk/pull/26