### PR TITLE
alternate method to remove auth data 

### DIFF
--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -582,7 +582,8 @@ class ParseUser extends ParseObject
     /**
      * Remove current user's anonymous AuthData
      */
-    private function clearAnonymousAuthData() {
+    private function clearAnonymousAuthData()
+    {
         $json = json_encode(['authData' => [ 'anonymous' => null]]);
         ParseClient::_request('PUT', 'classes/_User/' . $this->getObjectId(), null, $json, true);
     }
@@ -599,7 +600,7 @@ class ParseUser extends ParseObject
         if ($this->getObjectId()) {
             $wasAnonymous = isset($this->operationSet['username']) && $this->operationSet['username'] instanceof \Parse\Internal\SetOperation;
             parent::save($useMasterKey);
-            if($wasAnonymous) {
+            if ($wasAnonymous) {
                 $this->clearAnonymousAuthData();
             }
         } else {

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -51,7 +51,6 @@ class ParseUser extends ParseObject
      */
     public function setUsername($username)
     {
-        $this->set('authData.anonymous', null);
         return $this->set('username', $username);
     }
 
@@ -581,6 +580,14 @@ class ParseUser extends ParseObject
     }
 
     /**
+     * Remove current user's anonymous AuthData
+     */
+    private function clearAnonymousAuthData() {
+        $json = json_encode(['authData' => [ 'anonymous' => null]]);
+        ParseClient::_request('PUT', 'classes/_User/' . $this->getObjectId(), null, $json, true);
+    }
+
+    /**
      * Save the current user object, unless it is not signed up.
      *
      * @param bool $useMasterKey Whether to use the Master Key
@@ -590,7 +597,11 @@ class ParseUser extends ParseObject
     public function save($useMasterKey = false)
     {
         if ($this->getObjectId()) {
+            $wasAnonymous = isset($this->operationSet['username']) && $this->operationSet['username'] instanceof \Parse\Internal\SetOperation;
             parent::save($useMasterKey);
+            if($wasAnonymous) {
+                $this->clearAnonymousAuthData();
+            }
         } else {
             throw new ParseException(
                 'You must call signUp to create a new User.',

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -598,7 +598,8 @@ class ParseUser extends ParseObject
     public function save($useMasterKey = false)
     {
         if ($this->getObjectId()) {
-            $wasAnonymous = isset($this->operationSet['username']) && $this->operationSet['username'] instanceof \Parse\Internal\SetOperation;
+            $wasAnonymous = isset($this->operationSet['username'])
+                && $this->operationSet['username'] instanceof \Parse\Internal\SetOperation;
             parent::save($useMasterKey);
             if ($wasAnonymous) {
                 $this->clearAnonymousAuthData();


### PR DESCRIPTION
Has the added benefit of working with current versions of mongo :).

I copied this from https://github.com/parse-community/parse-server/blob/master/spec/ParseUser.spec.js#L2640

see: https://github.com/parse-community/parse-php-sdk/pull/427#issuecomment-458722990