### PR TITLE
Support query with count

### DIFF
--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -612,7 +612,7 @@ class ParseQuery
      * @return ParseQuery Returns this query, so you can chain this call.
      */
     public function withCount($includeCount = true)
-    {   
+    {
         $this->count = (int)$includeCount;
         return $this;
     }

--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -541,7 +541,7 @@ class ParseQuery
      * Execute a query to get only the first result.
      *
      * @param bool $useMasterKey If the query should use the master key
-     * @param bool $decodeObjects If set to false, will not return raw data instead of ParseObject instances
+     * @param bool $decodeObjects If set to false, will return raw data instead of ParseObject instances
      *
      * @return array|ParseObject Returns the first object or an empty array
      */
@@ -598,6 +598,23 @@ class ParseQuery
         );
 
         return $result['count'];
+    }
+
+    /**
+     * The response will include the total number of objects satisfying this query,
+     * dispite limit / skip. Might be useful for pagination.
+     *
+     * Note: the results will be an object
+     * `results`: holding {ParseObject} array and `count`: integer holding total number
+     *
+     * @param bool $includeCount If response should include count, true by default.
+     *
+     * @return ParseQuery Returns this query, so you can chain this call.
+     */
+    public function withCount($includeCount = true)
+    {   
+        $this->count = (int)$includeCount;
+        return $this;
     }
 
     /**
@@ -663,7 +680,7 @@ class ParseQuery
      * Execute a find query and return the results.
      *
      * @param bool $useMasterKey
-     * @param bool $decodeObjects If set to false, will not return raw data instead of ParseObject instances
+     * @param bool $decodeObjects If set to false, will return raw data instead of ParseObject instances
      *
      * @return ParseObject[]
      */
@@ -681,6 +698,27 @@ class ParseQuery
             null,
             $useMasterKey
         );
+
+        $response = [];
+        if (isset($result['count'])) {
+            $response['count'] = $result['count'];
+            $response['results'] = $this->handleQueryResult($result, $decodeObjects);
+            return $response;
+        }
+
+        return $this->handleQueryResult($result, $decodeObjects);
+    }
+
+    /**
+     * Handles result from ParseClient::_request
+     *
+     * @param array $result Array of ParseObject raw data.
+     * @param bool $decodeObjects If set to false, will return raw data instead of ParseObject instances
+     *
+     * @return Array Array of ParseObjects or raw data.
+     */
+    public function handleQueryResult($result, $decodeObjects)
+    {
         if (!isset($result['results'])) {
             return [];
         }

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -813,6 +813,131 @@ class ParseQueryTest extends TestCase
         );
     }
 
+    /**
+     * @group withCount
+     */
+    public function testWithCount()
+    {
+        Helper::clearClass('BoxedNumber');
+        $this->saveObjects(
+            3,
+            function ($i) {
+                $boxedNumber = ParseObject::create('BoxedNumber');
+                $boxedNumber->set('x', $i + 1);
+
+                return $boxedNumber;
+            }
+        );
+        $query = new ParseQuery('BoxedNumber');
+        $query->withCount();
+        $response = $query->find();
+        $this->assertEquals($response['count'], 3);
+        $this->assertEquals(count($response['results']), 3);
+    }
+
+    /**
+     * @group withCount
+     */
+    public function testWithCountDestructure()
+    {
+        Helper::clearClass('BoxedNumber');
+        $this->saveObjects(
+            3,
+            function ($i) {
+                $boxedNumber = ParseObject::create('BoxedNumber');
+                $boxedNumber->set('x', $i + 1);
+
+                return $boxedNumber;
+            }
+        );
+        $query = new ParseQuery('BoxedNumber');
+        $query->withCount();
+        ['count' => $count, 'results' => $results] = $query->find();
+        $this->assertEquals($count, 3);
+        $this->assertEquals(count($results), 3);
+    }
+
+    /**
+     * @group withCount
+     */
+    public function testWithCountFalse()
+    {
+        Helper::clearClass('BoxedNumber');
+        $this->saveObjects(
+            3,
+            function ($i) {
+                $boxedNumber = ParseObject::create('BoxedNumber');
+                $boxedNumber->set('x', $i + 1);
+
+                return $boxedNumber;
+            }
+        );
+        $query = new ParseQuery('BoxedNumber');
+        $query->withCount(false);
+        $response = $query->find();
+        $this->assertEquals(isset($response['count']), false);
+        $this->assertEquals(count($response), 3);
+    }
+
+    /**
+     * @group withCount
+     */
+    public function testWithCountEmptyClass()
+    {
+        Helper::clearClass('BoxedNumber');
+        $query = new ParseQuery('BoxedNumber');
+        $query->withCount();
+        $response = $query->find();
+        $this->assertEquals($response['count'], 0);
+        $this->assertEquals(count($response['results']), 0);
+    }
+
+    /**
+     * @group withCount
+     */
+    public function testWithCountAndLimit()
+    {
+        Helper::clearClass('BoxedNumber');
+        $this->saveObjects(
+            4,
+            function ($i) {
+                $boxedNumber = ParseObject::create('BoxedNumber');
+                $boxedNumber->set('x', $i + 1);
+
+                return $boxedNumber;
+            }
+        );
+        $query = new ParseQuery('BoxedNumber');
+        $query->withCount();
+        $query->limit(2);
+        $response = $query->find();
+        $this->assertEquals($response['count'], 4);
+        $this->assertEquals(count($response['results']), 2);
+    }
+
+    /**
+     * @group withCount
+     */
+    public function testWithCountAndSkip()
+    {
+        Helper::clearClass('BoxedNumber');
+        $this->saveObjects(
+            4,
+            function ($i) {
+                $boxedNumber = ParseObject::create('BoxedNumber');
+                $boxedNumber->set('x', $i + 1);
+
+                return $boxedNumber;
+            }
+        );
+        $query = new ParseQuery('BoxedNumber');
+        $query->withCount();
+        $query->skip(3);
+        $response = $query->find();
+        $this->assertEquals($response['count'], 4);
+        $this->assertEquals(count($response['results']), 1);
+    }
+
     public function testCountError()
     {
         $query = new ParseQuery('Test');


### PR DESCRIPTION
See https://github.com/parse-community/Parse-SDK-JS/pull/868

```
$query->withCount();
$response = $query->find();
$response['count'] // total number of objects despite limit / skip
$response['results'] // Array of objects
```

As of PHP 7.1 you can use Array Destructuring like es6

```
['count' => $count, 'results' => $results] = $query->find();
$count // total
$results // array
```