### PR TITLE
 Deprecation issue fixed in ParseUser class

### DIFF
--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -214,9 +214,8 @@ class ParseUser extends ParseObject
         $screen_name,
         $consumer_key,
         $consumer_secret = null,
-        //@codingStandardsIgnoreLine
-        $auth_token,
-        $auth_token_secret
+        $auth_token = null,
+        $auth_token_secret = null
     ) {
 
         if (!$id) {
@@ -382,9 +381,8 @@ class ParseUser extends ParseObject
         $screen_name,
         $consumer_key,
         $consumer_secret = null,
-        //@codingStandardsIgnoreLine
-        $auth_token,
-        $auth_token_secret,
+        $auth_token = null,
+        $auth_token_secret = null,
         $useMasterKey = false
     ) {
 


### PR DESCRIPTION
Set default value for argument in order to resolve deprecation issue.