### PR TITLE
ci: Change API Documentation template style

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ ParseClient::setCAFile(__DIR__ . '/certs/cacert.pem');
 
 We highly recommend you read through the [guide](http://docs.parseplatform.org/php/guide/) first. This will walk you through the basics of working with this sdk, as well as provide insight into how to best develop your project.
 
-If want to know more about what makes the php sdk tick you can read our [API Reference](http://parseplatform.org/parse-php-sdk/namespaces/Parse.html) and flip through the code on [github](https://github.com/parse-community/parse-php-sdk/).
+If want to know more about what makes the php sdk tick you can read our [API Reference](http://parseplatform.org/parse-php-sdk/namespaces/parse.html) and flip through the code on [github](https://github.com/parse-community/parse-php-sdk/).
 
 Check out the [Parse PHP Guide] for the full documentation.
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "prestart": "MONGODB_VERSION=4.0.4 MONGODB_TOPOLOGY=replicaset MONGODB_STORAGE_ENGINE=wiredTiger mongodb-runner start",
     "start": "TESTING=1 node ./tests/server.js &",
     "server-only": "TESTING=1 node ./tests/server.js",
-    "document-check": "./vendor/bin/phpdoc -d ./src/ --template='responsive-twig'",
-    "document": "./vendor/bin/phpdoc -d ./src/ --title 'Parse PHP SDK API Reference' --template='responsive-twig'"
+    "document-check": "./vendor/bin/phpdoc -d ./src/ --template='default'",
+    "document": "./vendor/bin/phpdoc -d ./src/ --title 'Parse PHP SDK API Reference' --template='default'"
   },
   "type": "module",
   "repository": {
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/parse-community/parse-php-sdk"
   },
   "license": "BSD-3-Clause",
-  "homepage": "https://github.com/montymxb/parse-server-test#readme",
+  "homepage": "https://parseplatform.org",
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "9.0.2",

--- a/src/Parse/ParseBytes.php
+++ b/src/Parse/ParseBytes.php
@@ -55,7 +55,7 @@ class ParseBytes implements Encodable
     /**
      * Decodes and unpacks a given base64 encoded array of data
      *
-     * @param $base64Data
+     * @param string $base64Data
      */
     private function setBase64Data($base64Data)
     {

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -164,8 +164,8 @@ class ParseFile implements Encodable
     /**
      * Internal method used when constructing a Parse File from Parse.
      *
-     * @param $name
-     * @param $url
+     * @param string $name
+     * @param string $url
      *
      * @return ParseFile
      */

--- a/src/Parse/ParseGeoPoint.php
+++ b/src/Parse/ParseGeoPoint.php
@@ -54,7 +54,7 @@ class ParseGeoPoint implements Encodable
     /**
      * Set the Latitude value for this GeoPoint.
      *
-     * @param $lat
+     * @param float $lat
      *
      * @throws ParseException
      */
@@ -82,7 +82,7 @@ class ParseGeoPoint implements Encodable
     /**
      * Set the Longitude value for this GeoPoint.
      *
-     * @param $lon
+     * @param float $lon
      *
      * @throws ParseException
      */

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -1548,7 +1548,7 @@ class ParseObject implements Encodable
     /**
      * Check whether there is a subclass registered for a given parse class.
      *
-     * @param $parseClassName
+     * @param string $parseClassName
      *
      * @return bool
      */
@@ -1561,7 +1561,7 @@ class ParseObject implements Encodable
      * Get the registered subclass for a Parse class, or a generic ParseObject
      * if no subclass is registered.
      *
-     * @param $parseClassName
+     * @param string $parseClassName
      *
      * @return ParseObject
      */

--- a/src/Parse/ParseRelation.php
+++ b/src/Parse/ParseRelation.php
@@ -95,7 +95,7 @@ class ParseRelation implements Encodable
     /**
      * Set the target classname for the relation.
      *
-     * @param $className
+     * @param string $className
      */
     public function setTargetClass($className)
     {
@@ -105,7 +105,7 @@ class ParseRelation implements Encodable
     /**
      * Set the parent object for the relation.
      *
-     * @param $parent
+     * @param ParseObject $parent
      */
     public function setParent($parent)
     {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-php-sdk/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-php-sdk/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Links are broken when using responsive-twig phpdocs template

Closes: https://github.com/parse-community/parse-php-sdk/issues/495

### Approach
<!-- Add a description of the approach in this PR. -->
* Change PHPDocs template to default
* Fix documentation errors
* Update links in readme
