### PR TITLE
ci: Fix auto-release version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,5 @@ jobs:
       - run: npm run document
         env:
           CI: true
+      - run: sed -i'' -r "s/const VERSION_STRING = '.*'/const VERSION_STRING = '2.1.0'/" ./src/Parse/ParseClient.php
       - run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,4 @@ jobs:
       - run: npm run document
         env:
           CI: true
-      - run: sed -i'' -r "s/const VERSION_STRING = '.*'/const VERSION_STRING = '2.1.0'/" ./src/Parse/ParseClient.php
       - run: bash <(curl -s https://codecov.io/bash)

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -79,7 +79,8 @@ async function config() {
         'changelogFile': changelogFile,
       }],
       ["@semantic-release/exec", {
-        "prepareCmd": `sed -i '' -r "s/const VERSION_STRING = '.*'/const VERSION_STRING = '\${nextRelease.version}'/" ./src/Parse/ParseClient.php`
+        // Update Parse SDK version
+        "prepareCmd": `sed -i'' -r "s/const VERSION_STRING = '.*'/const VERSION_STRING = '\${nextRelease.version}'/" ./src/Parse/ParseClient.php`
       }],
       ['@semantic-release/npm', {
         'npmPublish': false,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-php-sdk/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-php-sdk/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Auto-release script fails because `sed` command that bumps the version has a different syntax on ubuntu.

Closes: #493 

### Approach

Adapt syntax.
