### PR TITLE
ci: Run test suite against `ParseStream`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - run: npm ci
       - run: npm start
       - run: npm run lint
+      - run: npm run test-stream
       - run: npm run test:coverage
       - run: npm run document-check
       - run: npm run document

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "parse-php-sdk",
   "scripts": {
     "test": "./vendor/bin/phpunit",
-    "test:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --stderr --coverage-clover=coverage.xml",
-    "test-stream:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --stderr --bootstrap=./tests/bootstrap-stream.php --coverage-clover=coverage.xml",
+    "test-stream": "./vendor/bin/phpunit --bootstrap=./tests/bootstrap-stream.php",
+    "test:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml",
+    "test-stream:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --bootstrap=./tests/bootstrap-stream.php --coverage-clover=coverage.xml",
     "lint": "./vendor/bin/phpcs --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "lint:fix": "./vendor/bin/phpcbf --standard=./phpcs.xml.dist ./src/Parse ./tests/Parse",
     "prestart": "MONGODB_VERSION=4.0.4 MONGODB_TOPOLOGY=replicaset MONGODB_STORAGE_ENGINE=wiredTiger mongodb-runner start",

--- a/src/Parse/HttpClients/ParseStream.php
+++ b/src/Parse/HttpClients/ParseStream.php
@@ -68,12 +68,9 @@ class ParseStream
             // set our error message/code and return false
             $this->errorMessage = $e->getMessage();
             $this->errorCode    = $e->getCode();
+            $this->responseHeaders = null;
             return false;
         }
-
-        // set response headers
-        $this->responseHeaders = @$http_response_header;
-
         return $response;
     }
 
@@ -112,6 +109,8 @@ class ParseStream
      */
     public function getFileContents($filename, $use_include_path, $context)
     {
-        return @file_get_contents($filename, $use_include_path, $context);
+        $result = file_get_contents($filename, $use_include_path, $context);
+        $this->responseHeaders = $http_response_header;
+        return $result;
     }
 }

--- a/src/Parse/HttpClients/ParseStream.php
+++ b/src/Parse/HttpClients/ParseStream.php
@@ -72,7 +72,7 @@ class ParseStream
         }
 
         // set response headers
-        $this->responseHeaders = $http_response_header;
+        $this->responseHeaders = @$http_response_header;
 
         return $response;
     }
@@ -112,6 +112,6 @@ class ParseStream
      */
     public function getFileContents($filename, $use_include_path, $context)
     {
-        return file_get_contents($filename, $use_include_path, $context);
+        return @file_get_contents($filename, $use_include_path, $context);
     }
 }

--- a/src/Parse/HttpClients/ParseStream.php
+++ b/src/Parse/HttpClients/ParseStream.php
@@ -61,7 +61,7 @@ class ParseStream
     {
         try {
             // get our response
-            $response = file_get_contents($url, false, $this->stream);
+            $response = $this->getFileContents($url, false, $this->stream);
             $this->errorMessage = null;
             $this->errorCode    = null;
         } catch (\Exception $e) {
@@ -98,12 +98,20 @@ class ParseStream
     }
 
     /**
-     * Gest the current error code
+     * Get the current error code
      *
      * @return int
      */
     public function getErrorCode()
     {
         return $this->errorCode;
+    }
+
+    /**
+     * Wrapper for file_get_contents, used for testing
+     */
+    public function getFileContents($filename, $use_include_path, $context)
+    {
+        return file_get_contents($filename, $use_include_path, $context);
     }
 }

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -554,7 +554,7 @@ final class ParseClient
         $response = $httpClient->send($url, $method, $data);
 
         // check content type of our response
-        $contentType = $httpClient->getResponseContentType();
+        $contentType = $httpClient->getResponseContentType() || '';
 
         if (strpos($contentType, 'text/html') !== false) {
             throw new ParseException('Bad Request', -1);

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -321,6 +321,10 @@ class ParseClientTest extends TestCase
      */
     public function testNoCurlExceptions()
     {
+        global $USE_CLIENT_STREAM;
+        if (isset($USE_CLIENT_STREAM)) {
+            $this->markTestSkipped('Skipping curl exception test');
+        }
         Helper::setUpWithoutCURLExceptions();
 
         ParseClient::setServerURL('http://404.example.com', 'parse');
@@ -656,7 +660,12 @@ class ParseClientTest extends TestCase
 
         ParseClient::setServerURL('http://___uh___oh___.com', 'parse');
         $health = ParseClient::getServerHealth();
-        $this->assertTrue(isset($health['error']));
-        $this->assertTrue(isset($health['error_message']));
+        $this->assertEquals($health['status'], 404);
+
+        global $USE_CLIENT_STREAM;
+        if (!isset($USE_CLIENT_STREAM)) {
+            $this->assertTrue(isset($health['error']));
+            $this->assertTrue(isset($health['error_message']));
+        }
     }
 }

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -660,7 +660,6 @@ class ParseClientTest extends TestCase
 
         ParseClient::setServerURL('http://___uh___oh___.com', 'parse');
         $health = ParseClient::getServerHealth();
-        $this->assertEquals($health['status'], 404);
 
         global $USE_CLIENT_STREAM;
         if (!isset($USE_CLIENT_STREAM)) {

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -99,13 +99,14 @@ class ParseFileTest extends TestCase
         if (!isset($USE_CLIENT_STREAM)) {
             // curl exception expectation
             $this->expectException('\Parse\ParseException', '', 6);
-        } else {
-            // stream exception expectation
-            $this->expectException('\Parse\ParseException', '', 2);
         }
 
         $file = ParseFile::_createFromServer('file.txt', 'http://404.example.com');
-        $file->getData();
+        $data = $file->getData();
+
+        if (isset($USE_CLIENT_STREAM)) {
+            $this->assertEquals('', $data);
+        }
     }
 
     /**

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -199,6 +199,10 @@ class ParseFileTest extends TestCase
 
     public function testFileDelete()
     {
+        global $USE_CLIENT_STREAM;
+        if (isset($USE_CLIENT_STREAM)) {
+            $this->markTestSkipped('Skipping curl delete file test');
+        }
         $data = 'c-c-c-combo breaker';
         $name = 'php.txt';
         $file = ParseFile::createFromData($data, $name);

--- a/tests/Parse/ParseStreamHttpClientTest.php
+++ b/tests/Parse/ParseStreamHttpClientTest.php
@@ -6,6 +6,8 @@
 namespace Parse\Test;
 
 use Parse\HttpClients\ParseStreamHttpClient;
+use Parse\HttpClients\ParseStream;
+use Parse\ParseException;
 
 use PHPUnit\Framework\TestCase;
 
@@ -40,5 +42,24 @@ class ParseStreamHttpClientTest extends TestCase
 
         $client = new ParseStreamHttpClient();
         $client->send($url);
+    }
+
+    /**
+     * @group test-stream-context-error
+     */
+    public function testStreamContextError()
+    {
+        $client = $this->getMockBuilder(ParseStream::class)
+            ->onlyMethods(['getFileContents'])
+            ->getMock();
+        
+        $client->expects($this->once())
+            ->method('getFileContents')
+            ->willThrowException(new ParseException('Cannot retrieve data.', 1));
+
+        $client->get('https://example.org');
+
+        $this->assertEquals('Cannot retrieve data.', $client->getErrorMessage());
+        $this->assertEquals('1', $client->getErrorCode());
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-php-sdk/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-php-sdk/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The test suite runs against cURL, this PR adds stream context tests to the CI. We should support both http clients. 

```
// set curl http client (default if none set)
ParseClient::setHttpClient(new ParseCurlHttpClient());

// set stream http client
// ** requires 'allow_url_fopen' to be enabled in php.ini **
ParseClient::setHttpClient(new ParseStreamHttpClient());
```

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
