### PR TITLE
ci: Prevent concurrent CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,6 @@ jobs:
         env:
           CI: true
       - run: bash <(curl -s https://codecov.io/bash)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-php-sdk/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-php-sdk/issues?q=is%3Aissue).

### Issue Description

CI workflows can run concurrently when a new commit is pushed on a PR. This uses GitHub Action resources unnecessarily.

### Approach

Cancel any currently running workflows from previous PR commits.

